### PR TITLE
add message mapping for getaddinfo opt 24(0x18)

### DIFF
--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -630,6 +630,7 @@ pub(crate) fn dns_getaddrinfo_opts(data: &str) -> String {
     let message = match data {
         "8" => "0x8 {use-failover}",
         "12" => "0xC {in-app-browser, use-failover}",
+        "24" => "0x18 {use-failover, prohibit-encrypted-dns}",
         _ => {
             warn!("[macos-unifiedlogs] Unknown getaddrinfo options: {}", data);
             data


### PR DESCRIPTION
Thank you for making such a great tool :)
I found a log that allows message mapping, so I added the mapping.

## What Changed
- Fixed #5 
- Added log message mapping for `getaddinfo opt 24(0x18)`

## Evidence
### Environment 
- OS: macOS Ventura version 13.3.1(a)
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8, Chip: Apple M1

###  `unifiedlog_parser` CSV ouput
In this PR, you will be able to output `getaddinfo opt 24(0x18)` log messages as follows.
```
2023-05-25T14:26:01.419Z,Log,Default,com.apple.mdns,1320352,445,65,/usr/sbin/mDNSResponder,00AA92CEB5C83C1782B3C618AB43D536,2671035,dnssd_server,/usr/sbin/mDNSResponder,00AA92CEB5C83C1782B3C618AB43D536,"[R30457] getaddrinfo start -- flags: 0xFFFFFFFFC000D000, ifindex: 0, protocols: 0, hostname: 3/4T+tvoxjZTC4YJDAjvdw==, options: 0x18 {use-failover, prohibit-encrypted-dns}, client pid: 7235 (CFNetworkAgent), delegator uuid: CD0C63A5B47E36A8A97506EF3C6870CC","[R%u] getaddrinfo start -- flags: 0x%X, ifindex: %d, protocols: %u, hostname: %{sensitive,mask.hash}s, options: %{mdns:gaiopts}X, client pid: %lld (%{public}s), delegator uuid: %{public,uuid_t}.16P",6B6698629D8A4B5A84C114B938C396DF,Tokyo
```
I would appreciate it if you could review it.
Regards,