### PR TITLE
add message mapping for dns records any(255)

### DIFF
--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -445,6 +445,7 @@ pub(crate) fn dns_records(data: &str) -> String {
         "109" => "EUI64",
         "249" => "TKEY",
         "250" => "TSIG",
+        "255" => "ANY",
         "256" => "URI",
         "257" => "CAA",
         "32768" => "TA",


### PR DESCRIPTION
Hello :) 
I found a log that allows message mapping, so I added the mapping.

## What Changed
- Fixed #6 
- Added log message mapping for `dns records any(255)`

## Evidence
### Environment 
- OS: macOS Ventura version 13.3.1(a)
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8, Chip: Apple M1

###  `unifiedlog_parser` Output CSV
In this PR, you will be able to output `dns records any(255)` log messages as follows.
```
2023-05-25T13:37:41.229Z,Log,Default,com.apple.mDNSResponder,3607,445,65,/usr/sbin/mDNSResponder,00AA92CEB5C83C1782B3C618AB43D536,0,Default,/usr/sbin/mDNSResponder,00AA92CEB5C83C1782B3C618AB43D536,"[R29583] DNSServiceQueryRecord(11000, 0, 2S+1MK3Jk+97IvLE4BcGzw==, ANY) STOP PID[97042](com.docker.back)","[R%u] DNSServiceQueryRecord(%X, %d, %{sensitive, mask.hash, mdnsresponder:domain_name}.*P, %{public}s) STOP PID[%d](%{public}s)",6B6698629D8A4B5A84C114B938C396DF,Tokyo
```
I would appreciate it if you could review it.
Regards,