### PR TITLE
add message mapping for getaddinfo opt 0(0x0)

### DIFF
--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -629,6 +629,7 @@ pub(crate) fn dns_acceptable(data: &str) -> String {
 /// Translate DNS getaddrinfo log values
 pub(crate) fn dns_getaddrinfo_opts(data: &str) -> String {
     let message = match data {
+        "0" => "0x0 {}",
         "8" => "0x8 {use-failover}",
         "12" => "0xC {in-app-browser, use-failover}",
         "24" => "0x18 {use-failover, prohibit-encrypted-dns}",


### PR DESCRIPTION
Thank you for maintaining tool :)
I found a log that allows message mapping, so I added the mapping.

## What Changed
- Fixed #7
- Added log message mapping for `getaddinfo opt 0(0x0)`

## Evidence
### Environment 
- OS: macOS Ventura version 13.3.1(a)
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8, Chip: Apple M1

###  `unifiedlog_parser` CSV ouput
In this PR, you will be able to output `getaddinfo opt 0(0x0)` log messages as follows.
```
2023-05-30T11:13:50.048Z,Log,Default,com.apple.mdns,226945,499,65,/usr/sbin/mDNSResponder,00AA92CEB5C83C1782B3C618AB43D536,0,dnssd_server,/usr/sbin/mDNSResponder,00AA92CEB5C83C1782B3C618AB43D536,"[R4803] getaddrinfo start -- flags: 0xFFFFFFFFC808D000, ifindex: 0, protocols: 0, hostname: 9gRtAPDFjP3TqhKR60S6Lw==, options: 0x0 {}, client pid: 7585 (com.apple.Safar)","[R%u] getaddrinfo start -- flags: 0x%X, ifindex: %d, protocols: %u, hostname: %{sensitive,mask.hash}s, options: %{mdns:gaiopts}X, client pid: %lld (%{public}s)",FF30E7BF418742AC8F48E8CAF8C6C9DA,Tokyo
```
I would appreciate it if you could review it.
Regards,