### PR TITLE
Use u32 for FirehoseNonActivity::data_ref_value & Oversize tracking for HighVolume directory

### DIFF
--- a/examples/unifiedlog_parser/src/main.rs
+++ b/examples/unifiedlog_parser/src/main.rs
@@ -214,13 +214,15 @@ fn parse_trace_file(
             let full_path = data.path().display().to_string();
             println!("Parsing: {}", full_path);
 
-            let log_data = if data.path().exists() {
+            let mut log_data = if data.path().exists() {
                 parse_log(&full_path).unwrap()
             } else {
                 println!("File {} no longer on disk", full_path);
                 continue;
             };
 
+            // Append our old Oversize entries in case these logs point to other Oversize entries the previous tracev3 files
+            log_data.oversize.append(&mut oversize_strings.oversize);
             let (results, missing_logs) = build_log(
                 &log_data,
                 string_results,
@@ -229,7 +231,9 @@ fn parse_trace_file(
                 exclude_missing,
             );
 
-            // Signposts have not been seen with Oversize entries
+            // Signposts have not been seen with Oversize entries, but we track them in case a log entry refers to them
+            oversize_strings.oversize = log_data.oversize;
+            // Track missing logs
             missing_data.push(missing_logs);
             log_count += results.len();
 

--- a/examples/unifiedlog_parser/src/main.rs
+++ b/examples/unifiedlog_parser/src/main.rs
@@ -248,12 +248,15 @@ fn parse_trace_file(
             let full_path = data.path().display().to_string();
             println!("Parsing: {}", full_path);
 
-            let log_data = if data.path().exists() {
+            let mut log_data = if data.path().exists() {
                 parse_log(&full_path).unwrap()
             } else {
                 println!("File {} no longer on disk", full_path);
                 continue;
             };
+
+            // Append our old Oversize entries in case these logs point to other Oversize entries the previous tracev3 files
+            log_data.oversize.append(&mut oversize_strings.oversize);
             let (results, missing_logs) = build_log(
                 &log_data,
                 string_results,
@@ -262,7 +265,9 @@ fn parse_trace_file(
                 exclude_missing,
             );
 
-            // Oversize entries have not been seen in logs in HighVolume
+            // Track Oversize entries
+            oversize_strings.oversize = log_data.oversize;
+            // Track missing logs
             missing_data.push(missing_logs);
             log_count += results.len();
 

--- a/examples/unifiedlog_parser_json/src/main.rs
+++ b/examples/unifiedlog_parser_json/src/main.rs
@@ -223,13 +223,15 @@ fn parse_trace_file(
             let full_path = data.path().display().to_string();
             println!("Parsing: {}", full_path);
 
-            let log_data = if data.path().exists() {
+            let mut log_data = if data.path().exists() {
                 parse_log(&full_path).unwrap()
             } else {
                 println!("File {} no longer on disk", full_path);
                 continue;
             };
 
+            // Append our old Oversize entries in case these logs point to other Oversize entries the previous tracev3 files
+            log_data.oversize.append(&mut oversize_strings.oversize);
             let (results, missing_logs) = build_log(
                 &log_data,
                 string_results,
@@ -238,7 +240,9 @@ fn parse_trace_file(
                 exclude_missing,
             );
 
-            // Signposts have not been seen with Oversize entries
+            // Signposts have not been seen with Oversize entries, but we track them in case a log entry refers to them
+            oversize_strings.oversize = log_data.oversize;
+            // Track missing logs
             missing_data.push(missing_logs);
             log_count += results.len();
 

--- a/examples/unifiedlog_parser_json/src/main.rs
+++ b/examples/unifiedlog_parser_json/src/main.rs
@@ -280,7 +280,7 @@ fn parse_trace_file(
 
             // Track Oversize entries
             oversize_strings.oversize = log_data.oversize;
-            // Oversize entries have not been seen in logs in HighVolume
+            // Track missing logs
             missing_data.push(missing_logs);
             log_count += results.len();
 

--- a/examples/unifiedlog_parser_json/src/main.rs
+++ b/examples/unifiedlog_parser_json/src/main.rs
@@ -259,12 +259,17 @@ fn parse_trace_file(
         for log_path in paths {
             let data = log_path.unwrap();
             let full_path = data.path().display().to_string();
-            let log_data = if data.path().exists() {
+            println!("Parsing: {}", full_path);
+
+            let mut log_data = if data.path().exists() {
                 parse_log(&full_path).unwrap()
             } else {
                 println!("File {} no longer on disk", full_path);
                 continue;
             };
+
+            // Append our old Oversize entries in case these logs point to other Oversize entries the previous tracev3 files
+            log_data.oversize.append(&mut oversize_strings.oversize);
             let (results, missing_logs) = build_log(
                 &log_data,
                 string_results,
@@ -273,6 +278,8 @@ fn parse_trace_file(
                 exclude_missing,
             );
 
+            // Track Oversize entries
+            oversize_strings.oversize = log_data.oversize;
             // Oversize entries have not been seen in logs in HighVolume
             missing_data.push(missing_logs);
             log_count += results.len();

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -27,7 +27,7 @@ pub struct FirehoseNonActivity {
     pub unknown_message_string_ref: u32, // if flag 0x0008
     pub subsystem_value: u16,            // if flag 0x200, has_subsystem
     pub ttl_value: u8,                   // if flag 0x0400, has_rules
-    pub data_ref_value: u16,             // if flag 0x0800, has_oversize
+    pub data_ref_value: u32,             // if flag 0x0800, has_oversize
     pub unknown_pc_id: u32, // Appears to be used to calculate string offset for firehose events with Absolute flag
     pub firehose_formatters: FirehoseFormatters,
 }
@@ -121,8 +121,8 @@ impl FirehoseNonActivity {
         let data_ref: u16 = 0x800; // has_oversize flag
         if (firehose_flags & data_ref) != 0 {
             debug!("[macos-unifiedlogs] Non-Activity Firehose log chunk has has_oversize flag");
-            let (firehose_input, data_ref_value) = take(size_of::<u16>())(input)?;
-            let (_, firehose_data_ref) = le_u16(data_ref_value)?;
+            let (firehose_input, data_ref_value) = take(size_of::<u32>())(input)?;
+            let (_, firehose_data_ref) = le_u32(data_ref_value)?;
             non_activity.data_ref_value = firehose_data_ref;
             input = firehose_input;
         }

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -27,7 +27,7 @@ pub struct FirehoseSignpost {
     pub private_strings_offset: u16, // if flag 0x0100
     pub private_strings_size: u16,   // if flag 0x0100
     pub ttl_value: u8,
-    pub data_ref_value: u16, // if flag 0x0800, has_oversize
+    pub data_ref_value: u32, // if flag 0x0800, has_oversize
     pub firehose_formatters: FirehoseFormatters,
 }
 
@@ -125,8 +125,8 @@ impl FirehoseSignpost {
         let data_ref: u16 = 0x800; // has_oversize flag
         if (firehose_flags & data_ref) != 0 {
             debug!("[macos-unifiedlogs] Signpost Firehose log chunk has has_oversize flag");
-            let (firehose_input, data_ref_value) = take(size_of::<u16>())(input)?;
-            let (_, firehose_data_ref) = le_u16(data_ref_value)?;
+            let (firehose_input, data_ref_value) = take(size_of::<u32>())(input)?;
+            let (_, firehose_data_ref) = le_u32(data_ref_value)?;
             firehose_signpost.data_ref_value = firehose_data_ref;
             input = firehose_input;
         }


### PR DESCRIPTION
Hi,

Thanks for your great work with this library. I'm employing it to parse the file `system_logs.logarchive` of iOS sysdiagnoses and recently noticed that some log messages are missing in the library's output compared to the macOS Console application.

I've determined two causes for this issue, which this pull request intends to fix:
1. The log messages I'm interested in are stored in the `HighVolume` directory, and contrary to previous assumptions, trace3 files in this directory can contain oversize references.
2. The field `FirehoseNonActivity::data_ref_value` has a size of `u16`, while the field `Oversize::data_ref_index` has a size of `u32`. I observed the output of `log raw-dump` and found that the missing messages have oversize references with a value larger than `u16`. When parsing the field in question as `u32` we get oversize references similar to the program's output. We're allowed to parse 4 bytes for this field as the third byte was marked as an unknown value in the [unofficial specification](https://github.com/libyal/dtformats/blob/main/documentation/Apple%20Unified%20Logging%20and%20Activity%20Tracing%20formats.asciidoc#2108-log-firehose-tracepoint), and I assume that the fourth byte is also part of the reference value and does not indicate the number of data items as the data items for oversize references are stored within the oversize chunk. 

With these changes, the library can correctly identify and assign the oversize chunks for the previously missing messages.

Best
Lukas