### PR TITLE
chg: [unifiedlog_iterator] support jsonl output and more params

### DIFF
--- a/examples/unifiedlog_iterator/Cargo.toml
+++ b/examples/unifiedlog_iterator/Cargo.toml
@@ -10,5 +10,6 @@ simplelog = "0.12.2"
 csv = "1.3.0"
 chrono = "0.4.38"
 log = "0.4.22"
+serde_json = "1.0.122"
 macos-unifiedlogs = {path = "../../"}
 clap = {version = "4.5.18", features = ["derive"]}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -105,7 +105,7 @@ pub fn collect_strings(path: &str) -> Result<Vec<UUIDText>, ParserError> {
 
     let entries = paths
         .flat_map(|path| {
-            path.inspect_err(|err| {
+            path.map_err(|err| {
                 error!("[macos-unifiedlogs] Failed to get directory entry: {err:?}",)
             })
             .ok()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -105,9 +105,9 @@ pub fn collect_strings(path: &str) -> Result<Vec<UUIDText>, ParserError> {
 
     let entries = paths
         .flat_map(|path| {
-            path.map_err(|err| {
-                error!("[macos-unifiedlogs] Failed to get directory entry: {err:?}",)
-            })
+            path.map_err(
+                |err| error!("[macos-unifiedlogs] Failed to get directory entry: {err:?}",),
+            )
             .ok()
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
This change brings support for `jsonl` output. 
The output can be saved to a file, or to the standard output.
If the user does not specify the output format as `-f` parameter, it defaults to autodetect it based on the filename.
The user can also specify to `--append` append or not (default). I found the previous default of appending quite confusing.


Please do not hesitate to correct my code, as I'm not very familiar with Rust. 
For sanity check the csv output before and after my change is the same. 

The parameters are therefore now:
```
Usage: unifiedlog_iterator [OPTIONS]

Options:
  -l, --live <LIVE>      Run on live system [default: false]
  -i, --input <INPUT>    Path to logarchive formatted directory [default: ]
  -o, --output <OUTPUT>  Path to output file. Any directories must already exist [default: ]
  -f, --format <FORMAT>  Output format. Options: csv, jsonl. Default is autodetect [default: auto]
  -a, --append           Append to output file If false, will overwrite output file
  -h, --help             Print help
  -V, --version          Print version
```