### PR TITLE
shorter logpreamble parse implementation by more nom combinators usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ simplelog = "0.12.2"
 csv = "1.3.0"
 chrono = "0.4.38"
 criterion = "0.5.1"
+anyhow = "1.0.93"
 
 [[bench]]
 name = "high_sierra_benchmark"

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,7 @@ allow = [
     "BSL-1.0",
     "Unlicense",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
     clippy::checked_conversions,
     clippy::unnecessary_cast
 )]
+
 mod catalog;
 mod chunks;
 mod chunkset;


### PR DESCRIPTION
Hello @puffyCid 

This is a revival of the too ambitious https://github.com/mandiant/macos-UnifiedLogs/pull/22.

I plan to provide you with a lot of small, easy to review&merge PRs like this one.

So in this first one : `LogPreamble`
- more `nom` combinators usage 
  * direct parsing integers (no need to take then parse)
  * direct parsing 3 elements (using nom `tuple` combinator)
  * direct final struct creation (no `mut` needed)
  
- added anyhow `dev` dependency for easy error handling
  * no panicable code (I tend to avoid `unwrap`s even in test code when I can)

- added a `parse` function the consumes the input.
  * its not really used yet, cause the `detect` one is use
  * but the detect one makes you re-parse preamble again in other chunks parser, it's a waste.
  * so i'll probably slowly migrate to the `parse/consuming` function in the next submissions


Tell me what you think about this plan ?