### PR TITLE
Basic Protobuf parsing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ plist = "1.7.0"
 regex = "1.10.6"
 base64 = "0.22.1"
 chrono = "0.4.38"
+sunlight = "0.1.0"
 
 [dev-dependencies]
 simplelog = "0.12.2"

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -24,12 +24,13 @@ use crate::header::HeaderChunk;
 use crate::message::format_firehose_log_message;
 use crate::preamble::LogPreamble;
 use crate::timesync::TimesyncBoot;
-use crate::util::{extract_string, padding_size, unixepoch_to_iso};
+use crate::util::{encode_standard, extract_string, padding_size, unixepoch_to_iso};
 use crate::uuidtext::UUIDText;
 use log::{error, warn};
 use nom::bytes::complete::take;
 use regex::Regex;
 use serde::Serialize;
+use sunlight::light::extract_protobuf;
 
 #[derive(Debug, Clone)]
 pub struct UnifiedLogData {
@@ -537,7 +538,17 @@ impl Iterator for LogIterator<'_> {
 
             let data_string = match statedump.unknown_data_type {
                 0x1 => Statedump::parse_statedump_plist(&statedump.statedump_data),
-                0x2 => String::from("Statedump Protocol Buffer"),
+                0x2 => {
+                    let result = extract_protobuf(&statedump.statedump_data);
+                    match result {
+                        Ok(map) => serde_json::to_string(&map)
+                            .unwrap_or(String::from("Failed to serialize Protobuf HashMap")),
+                        Err(_err) => format!(
+                            "Failed to parse StateDump protobuf: {}",
+                            encode_standard(&statedump.statedump_data)
+                        ),
+                    }
+                }
                 0x3 => Statedump::parse_statedump_object(
                     &statedump.statedump_data,
                     &statedump.title_name,


### PR DESCRIPTION
This PR adds [Sunlight](https://github.com/puffyCid/sunlight) a small basic protobuf parsing library to help extract data from Protobuf structures in the logs.

These structures are primarily found in Statedump entries. They seem to be very rare. The sunlight library has been tested on some samples, in addition it has been tested on some macOS BIOME files (which also contain Protobuf data)

PR is in draft for now, because the [tests.zip](https://github.com/mandiant/macos-UnifiedLogs/releases/download/v1.0.0/tests.zip) file will need to be updated because we extract more information and the assert comparisons will need to be upated