### PR TITLE
cleanup: Adds 'Default' trait to many structs

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -19,7 +19,7 @@ use crate::{
     util::{extract_string, padding_size},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CatalogChunk {
     pub chunk_tag: u32,
     pub chunk_sub_tag: u32,
@@ -37,7 +37,7 @@ pub struct CatalogChunk {
     pub catalog_subchunks: Vec<CatalogSubchunk>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ProcessInfoEntry {
     pub index: u16,
     pub unknown: u16, // flags?
@@ -59,7 +59,7 @@ pub struct ProcessInfoEntry {
 }
 
 // Part of ProcessInfoEntry
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ProcessUUIDEntry {
     pub size: u32,
     pub unknown: u32,
@@ -69,7 +69,7 @@ pub struct ProcessUUIDEntry {
 }
 
 // Part of ProcessInfoEntry
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ProcessInfoSubsystem {
     pub identifer: u16,
     pub subsystem_offset: u16, // Represents the offset to the subsystem from the start of the subsystem entries
@@ -77,7 +77,7 @@ pub struct ProcessInfoSubsystem {
 }
 
 // Part of CatalogChunk, possible 64-bit alignment padding at end
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CatalogSubchunk {
     pub start: u64,
     pub end: u64,
@@ -89,7 +89,7 @@ pub struct CatalogSubchunk {
     pub string_offsets: Vec<u16>, // string_offsets size = number_string_offsets * u16
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SubsystemInfo {
     pub subsystem: String,
     pub category: String,
@@ -98,22 +98,7 @@ pub struct SubsystemInfo {
 impl CatalogChunk {
     /// Parse log Catalog data. The log Catalog contains metadata related to log entries such as Process info, Subsystem info, and the compressed log entries
     pub fn parse_catalog(data: &[u8]) -> nom::IResult<&[u8], CatalogChunk> {
-        let mut catalog_chunk = CatalogChunk {
-            chunk_tag: 0,
-            chunk_sub_tag: 0,
-            chunk_data_size: 0,
-            catalog_subsystem_strings_offset: 0,
-            catalog_process_info_entries_offset: 0,
-            number_process_information_entries: 0,
-            catalog_offset_sub_chunks: 0,
-            number_sub_chunks: 0,
-            unknown: Vec::new(),
-            earliest_firehose_timestamp: 0,
-            catalog_uuids: Vec::new(),
-            catalog_subsystem_strings: Vec::new(),
-            catalog_process_info_entries: Vec::new(),
-            catalog_subchunks: Vec::new(),
-        };
+        let mut catalog_chunk = CatalogChunk::default();
 
         // Parse initial part Catalog chunk based on known sizes
         let (input, chunk_tag) = take(size_of::<u32>())(data)?;
@@ -217,25 +202,7 @@ impl CatalogChunk {
         data: &'a [u8],
         uuids: &[String],
     ) -> nom::IResult<&'a [u8], ProcessInfoEntry> {
-        let mut catalog_process_entry = ProcessInfoEntry {
-            index: 0,
-            unknown: 0,
-            catalog_main_uuid_index: 0,
-            catalog_dsc_uuid_index: 0,
-            first_number_proc_id: 0,
-            second_number_proc_id: 0,
-            pid: 0,
-            effective_user_id: 0,
-            unknown2: 0,
-            number_uuids_entries: 0,
-            unknown3: 0,
-            uuid_info_entries: Vec::new(),
-            number_subsystems: 0,
-            unknown4: 0,
-            subsystem_entries: Vec::new(),
-            main_uuid: String::new(),
-            dsc_uuid: String::new(),
-        };
+        let mut catalog_process_entry = ProcessInfoEntry::default();
 
         // Get all static sized data
         let (input, index) = take(size_of::<u16>())(data)?;
@@ -396,16 +363,7 @@ impl CatalogChunk {
 
     // Parse the Catalog Subchunk metadata. This metadata is related to the compressed (typically) Chunkset data
     fn parse_catalog_subchunk(data: &[u8]) -> nom::IResult<&[u8], CatalogSubchunk> {
-        let mut catalog_subchunk = CatalogSubchunk {
-            start: 0,
-            end: 0,
-            uncompressed_size: 0,
-            compression_algorithm: 0,
-            number_index: 0,
-            indexes: Vec::new(),
-            number_string_offsets: 0,
-            string_offsets: Vec::new(),
-        };
+        let mut catalog_subchunk = CatalogSubchunk::default();
 
         // Get static size subchunk data
         let (input, start) = take(size_of::<u64>())(data)?;
@@ -478,10 +436,7 @@ impl CatalogChunk {
         second_proc_id: &u32,
         catalog: &'a CatalogChunk,
     ) -> nom::IResult<&'a [u8], SubsystemInfo> {
-        let mut subsystem_info = SubsystemInfo {
-            subsystem: String::new(),
-            category: String::new(),
-        };
+        let mut subsystem_info = SubsystemInfo::default();
 
         // Go through catalog entries until first and second proc id match the log entry
         for process_info in &catalog.catalog_process_info_entries {

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -18,7 +18,7 @@ use nom::{
 };
 use std::mem::size_of;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FirehoseActivity {
     pub unknown_activity_id: u32,
     pub unknown_sentinal: u32,      // always 0x80000000?
@@ -40,28 +40,7 @@ impl FirehoseActivity {
         firehose_flags: &u16,
         firehose_log_type: &u8,
     ) -> nom::IResult<&'a [u8], FirehoseActivity> {
-        let mut activity = FirehoseActivity {
-            unknown_activity_id: 0,
-            unknown_sentinal: 0,
-            pid: 0,
-            unknown_activity_id_2: 0,
-            unknown_sentinal_2: 0,
-            unknown_activity_id_3: 0,
-            unknown_sentinal_3: 0,
-            unknown_message_string_ref: 0,
-            unknown_pc_id: 0,
-            firehose_formatters: FirehoseFormatters {
-                main_exe: false,
-                shared_cache: false,
-                has_large_offset: 0,
-                large_shared_cache: 0,
-                absolute: false,
-                uuid_relative: String::new(),
-                main_plugin: false,
-                pc_style: false,
-                main_exe_alt_index: 0,
-            },
-        };
+        let mut activity = FirehoseActivity::default();
         let mut input = data;
 
         // Useraction activity type does not have first Activity ID or sentinel

--- a/src/chunks/firehose/flags.rs
+++ b/src/chunks/firehose/flags.rs
@@ -11,7 +11,7 @@ use nom::number::complete::{be_u128, le_u16};
 use nom::Needed;
 use std::mem::size_of;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FirehoseFormatters {
     pub main_exe: bool,
     pub shared_cache: bool,
@@ -30,17 +30,8 @@ impl FirehoseFormatters {
         data: &'a [u8],
         firehose_flags: &u16,
     ) -> nom::IResult<&'a [u8], FirehoseFormatters> {
-        let mut formatter_flags = FirehoseFormatters {
-            main_exe: false,
-            shared_cache: false,
-            has_large_offset: 0,
-            large_shared_cache: 0,
-            absolute: false,
-            uuid_relative: String::new(),
-            main_plugin: false,
-            pc_style: false,
-            main_exe_alt_index: 0,
-        };
+        let mut formatter_flags = FirehoseFormatters::default();
+
         let message_strings_uuid: u16 = 0x2; // main_exe flag
         let large_shared_cache = 0xc; // large_shared_cache flag
         let large_offset = 0x20; // has_large_offset flag

--- a/src/chunks/firehose/loss.rs
+++ b/src/chunks/firehose/loss.rs
@@ -9,7 +9,7 @@ use nom::bytes::complete::take;
 use nom::number::complete::le_u64;
 use std::mem::size_of;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FirehoseLoss {
     pub start_time: u64,
     pub end_time: u64,
@@ -20,11 +20,7 @@ impl FirehoseLoss {
     /// Parse loss Firehose log entry.
     //  Ex: tp 16 + 48: loss
     pub fn parse_firehose_loss(data: &[u8]) -> nom::IResult<&[u8], FirehoseLoss> {
-        let mut firehose_loss = FirehoseLoss {
-            start_time: 0,
-            end_time: 0,
-            count: 0,
-        };
+        let mut firehose_loss = FirehoseLoss::default();
 
         let (input, start_time) = take(size_of::<u64>())(data)?;
         let (input, end_time) = take(size_of::<u64>())(input)?;

--- a/src/chunks/firehose/message.rs
+++ b/src/chunks/firehose/message.rs
@@ -13,7 +13,7 @@ use crate::dsc::SharedCacheStrings;
 use crate::util::extract_string;
 use crate::uuidtext::{UUIDText, UUIDTextEntry};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MessageData {
     pub library: String,
     pub format_string: String,
@@ -37,13 +37,7 @@ impl MessageData {
         original_offset: u64,
     ) -> nom::IResult<&'a [u8], MessageData> {
         debug!("[macos-unifiedlogs] Extracting format string from shared cache file (dsc)");
-        let mut message_data = MessageData {
-            library: String::new(),
-            format_string: String::new(),
-            process: String::new(),
-            library_uuid: String::new(),
-            process_uuid: String::new(),
-        };
+        let mut message_data = MessageData::default();
 
         // Check if the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0 {
@@ -187,13 +181,10 @@ impl MessageData {
         let (_, main_uuid) = MessageData::get_catalog_dsc(catalogs, first_proc_id, second_proc_id);
 
         // log entries with main_exe flag do not use dsc cache uuid file
-        let mut message_data = MessageData {
-            library: String::new(),
-            format_string: String::new(),
-            process: String::new(),
-            library_uuid: main_uuid.to_owned(),
-            process_uuid: main_uuid,
-        };
+        let mut message_data = MessageData::default();
+
+        message_data.library_uuid = main_uuid.to_owned();
+        message_data.process_uuid = main_uuid;
 
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0 {

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -18,7 +18,7 @@ use nom::{
 };
 use std::mem::size_of;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FirehoseNonActivity {
     pub unknown_activity_id: u32,        // if flag 0x0001
     pub unknown_sentinal: u32,           // always 0x80000000? if flag 0x0001
@@ -39,28 +39,8 @@ impl FirehoseNonActivity {
         data: &'a [u8],
         firehose_flags: &u16,
     ) -> nom::IResult<&'a [u8], FirehoseNonActivity> {
-        let mut non_activity = FirehoseNonActivity {
-            unknown_activity_id: 0,
-            unknown_sentinal: 0,
-            private_strings_offset: 0,
-            private_strings_size: 0,
-            unknown_message_string_ref: 0,
-            subsystem_value: 0,
-            ttl_value: 0,
-            data_ref_value: 0,
-            unknown_pc_id: 0,
-            firehose_formatters: FirehoseFormatters {
-                main_exe: false,
-                shared_cache: false,
-                has_large_offset: 0,
-                large_shared_cache: 0,
-                absolute: false,
-                uuid_relative: String::new(),
-                main_plugin: false,
-                pc_style: false,
-                main_exe_alt_index: 0,
-            },
-        };
+        let mut non_activity = FirehoseNonActivity::default();
+
         let mut input = data;
         let activity_id_current: u16 = 0x1; // has_current_aid flag
 

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -16,7 +16,7 @@ use nom::number::complete::{le_u16, le_u32, le_u64, le_u8};
 use nom::Needed;
 use std::mem::size_of;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FirehoseSignpost {
     pub unknown_pc_id: u32, // Appears to be used to calculate string offset for firehose events with Absolute flag
     pub unknown_activity_id: u32,
@@ -38,29 +38,7 @@ impl FirehoseSignpost {
         data: &'a [u8],
         firehose_flags: &u16,
     ) -> nom::IResult<&'a [u8], FirehoseSignpost> {
-        let mut firehose_signpost = FirehoseSignpost {
-            unknown_pc_id: 0,
-            unknown_activity_id: 0,
-            unknown_sentinel: 0,
-            subsystem: 0,
-            signpost_id: 0,
-            signpost_name: 0,
-            private_strings_offset: 0,
-            private_strings_size: 0,
-            ttl_value: 0,
-            firehose_formatters: FirehoseFormatters {
-                main_exe: false,
-                shared_cache: false,
-                has_large_offset: 0,
-                large_shared_cache: 0,
-                absolute: false,
-                uuid_relative: String::new(),
-                main_plugin: false,
-                pc_style: false,
-                main_exe_alt_index: 0,
-            },
-            data_ref_value: 0,
-        };
+        let mut firehose_signpost = FirehoseSignpost::default();
 
         let mut input = data;
 

--- a/src/chunks/firehose/trace.rs
+++ b/src/chunks/firehose/trace.rs
@@ -15,7 +15,7 @@ use crate::chunks::firehose::firehose_log::{FirehoseItemData, FirehoseItemInfo};
 use crate::chunks::firehose::message::MessageData;
 use crate::uuidtext::UUIDText;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FirehoseTrace {
     pub unknown_pc_id: u32, // Appears to be used to calculate string offset for firehose events with Absolute flag
     pub message_data: FirehoseItemData,
@@ -25,13 +25,8 @@ impl FirehoseTrace {
     /// Parse Trace Firehose log entry.
     //  Ex: tp 504 + 34: trace default (main_exe)
     pub fn parse_firehose_trace(data: &[u8]) -> nom::IResult<&[u8], FirehoseTrace> {
-        let mut firehose_trace = FirehoseTrace {
-            unknown_pc_id: 0,
-            message_data: FirehoseItemData {
-                item_info: Vec::new(),
-                backtrace_strings: Vec::new(),
-            },
-        };
+        let mut firehose_trace = FirehoseTrace::default();
+
         let (input, unknown_pc_id) = take(size_of::<u32>())(data)?;
         let (_, firehose_unknown_pc_id) = le_u32(unknown_pc_id)?;
 

--- a/src/chunks/oversize.rs
+++ b/src/chunks/oversize.rs
@@ -11,7 +11,7 @@ use nom::bytes::complete::take;
 use nom::number::complete::{le_u16, le_u32, le_u64, le_u8};
 use std::mem::size_of;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Oversize {
     pub chunk_tag: u32,
     pub chunk_subtag: u32,
@@ -30,23 +30,7 @@ pub struct Oversize {
 impl Oversize {
     /// Parse the oversize log entry. Oversize entries contain strings that are too large to fit in a normal Firehose log entry
     pub fn parse_oversize(data: &[u8]) -> nom::IResult<&[u8], Oversize> {
-        let mut oversize_results = Oversize {
-            chunk_tag: 0,
-            chunk_subtag: 0,
-            chunk_data_size: 0,
-            first_proc_id: 0,
-            second_proc_id: 0,
-            ttl: 0,
-            unknown_reserved: Vec::new(),
-            continuous_time: 0,
-            data_ref_index: 0,
-            public_data_size: 0,
-            private_data_size: 0,
-            message_items: FirehoseItemData {
-                item_info: Vec::new(),
-                backtrace_strings: Vec::new(),
-            },
-        };
+        let mut oversize_results = Oversize::default();
 
         let (input, chunk_tag) = take(size_of::<u32>())(data)?;
         let (input, chunk_sub_tag) = take(size_of::<u32>())(input)?;

--- a/src/chunks/simpledump.rs
+++ b/src/chunks/simpledump.rs
@@ -14,7 +14,7 @@ use std::mem::size_of;
    Introduced in macOS Monterey (12).  Appears to be a "simpler" version of Statedump?
    So far appears to just contain a single string
 */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SimpleDump {
     pub chunk_tag: u32,
     pub chunk_subtag: u32,
@@ -38,25 +38,8 @@ pub struct SimpleDump {
 impl SimpleDump {
     /// Parse Simpledump log entry.  Introduced in macOS Monterey (12)
     pub fn parse_simpledump(data: &[u8]) -> nom::IResult<&[u8], SimpleDump> {
-        let mut simpledump_resuls = SimpleDump {
-            chunk_tag: 0,
-            chunk_subtag: 0,
-            chunk_data_size: 0,
-            first_proc_id: 0,
-            second_proc_id: 0,
-            continous_time: 0,
-            thread_id: 0,
-            unknown_offset: 0,
-            unknown_ttl: 0,
-            unknown_type: 0,
-            sender_uuid: String::new(),
-            dsc_uuid: String::new(),
-            unknown_number_message_strings: 0,
-            unknown_size_subsystem_string: 0,
-            unknown_size_message_string: 0,
-            subsystem: String::new(),
-            message_string: String::new(),
-        };
+        let mut simpledump_resuls = SimpleDump::default();
+
         let (input, chunk_tag) = take(size_of::<u32>())(data)?;
         let (input, chunk_sub_tag) = take(size_of::<u32>())(input)?;
         let (input, chunk_data_size) = take(size_of::<u64>())(input)?;

--- a/src/chunks/statedump.rs
+++ b/src/chunks/statedump.rs
@@ -13,7 +13,7 @@ use nom::number::complete::{le_u32, le_u64, le_u8};
 use plist::Value;
 use std::mem::size_of;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Statedump {
     pub chunk_tag: u32,
     pub chunk_subtag: u32,
@@ -36,24 +36,8 @@ pub struct Statedump {
 impl Statedump {
     /// Parse Statedump log entry. Statedumps are special log entries that may contain a plist file, custom object, or protocol buffer
     pub fn parse_statedump(data: &[u8]) -> nom::IResult<&[u8], Statedump> {
-        let mut statedump_results = Statedump {
-            chunk_tag: 0,
-            chunk_subtag: 0,
-            chunk_data_size: 0,
-            first_proc_id: 0,
-            second_proc_id: 0,
-            ttl: 0,
-            unknown_reserved: Vec::new(),
-            continuous_time: 0,
-            activity_id: 0,
-            uuid: String::new(),
-            unknown_data_type: 0,
-            unknown_data_size: 0,
-            decoder_library: String::new(),
-            decoder_type: String::new(),
-            title_name: String::new(),
-            statedump_data: Vec::new(),
-        };
+        let mut statedump_results = Statedump::default();
+
         let (input, chunk_tag) = take(size_of::<u32>())(data)?;
         let (input, chunk_sub_tag) = take(size_of::<u32>())(input)?;
         let (input, chunk_data_size) = take(size_of::<u64>())(input)?;

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -22,7 +22,7 @@ use crate::{
     chunks::oversize::Oversize, preamble::LogPreamble, unified_log::UnifiedLogCatalogData,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ChunksetChunk {
     pub chunk_tag: u32,
     pub chunk_sub_tag: u32,
@@ -37,16 +37,7 @@ pub struct ChunksetChunk {
 impl ChunksetChunk {
     /// Parse the Chunkset data that contains the actual log entries
     pub fn parse_chunkset(data: &[u8]) -> nom::IResult<&[u8], ChunksetChunk> {
-        let mut chunkset_chunk = ChunksetChunk {
-            chunk_tag: 0,
-            chunk_sub_tag: 0,
-            chunk_data_size: 0,
-            signature: 0,
-            uncompress_size: 0,
-            block_size: 0,
-            decompressed_data: Vec::new(),
-            footer: 0,
-        };
+        let mut chunkset_chunk = ChunksetChunk::default();
 
         let (input, chunk_tag) = take(size_of::<u32>())(data)?;
         let (input, chunk_sub_tag) = take(size_of::<u32>())(input)?;
@@ -2304,28 +2295,7 @@ mod tests {
         test_path.push("tests/test_data/Chunkset Tests/big_sur_oversize_chunkset.raw");
         let buffer = fs::read(test_path).unwrap();
 
-        let mut unified_log = UnifiedLogCatalogData {
-            catalog: CatalogChunk {
-                chunk_tag: 0,
-                chunk_sub_tag: 0,
-                chunk_data_size: 0,
-                catalog_subsystem_strings_offset: 0,
-                catalog_process_info_entries_offset: 0,
-                number_process_information_entries: 0,
-                catalog_offset_sub_chunks: 0,
-                number_sub_chunks: 0,
-                unknown: Vec::new(),
-                earliest_firehose_timestamp: 0,
-                catalog_uuids: Vec::new(),
-                catalog_subsystem_strings: Vec::new(),
-                catalog_process_info_entries: Vec::new(),
-                catalog_subchunks: Vec::new(),
-            },
-            firehose: Vec::new(),
-            simpledump: Vec::new(),
-            statedump: Vec::new(),
-            oversize: Vec::new(),
-        };
+        let mut unified_log = UnifiedLogCatalogData::default();
 
         let oversize_chunk: u32 = 0x6002;
         ChunksetChunk::get_chunkset_data(&buffer, oversize_chunk, &mut unified_log);
@@ -2351,28 +2321,7 @@ mod tests {
         test_path.push("tests/test_data/Chunkset Tests/big_sur_statedump_chunkset.raw");
         let buffer = fs::read(test_path).unwrap();
 
-        let mut unified_log = UnifiedLogCatalogData {
-            catalog: CatalogChunk {
-                chunk_tag: 0,
-                chunk_sub_tag: 0,
-                chunk_data_size: 0,
-                catalog_subsystem_strings_offset: 0,
-                catalog_process_info_entries_offset: 0,
-                number_process_information_entries: 0,
-                catalog_offset_sub_chunks: 0,
-                number_sub_chunks: 0,
-                unknown: Vec::new(),
-                earliest_firehose_timestamp: 0,
-                catalog_uuids: Vec::new(),
-                catalog_subsystem_strings: Vec::new(),
-                catalog_process_info_entries: Vec::new(),
-                catalog_subchunks: Vec::new(),
-            },
-            firehose: Vec::new(),
-            simpledump: Vec::new(),
-            statedump: Vec::new(),
-            oversize: Vec::new(),
-        };
+        let mut unified_log = UnifiedLogCatalogData::default();
 
         let statedump_chunk = 0x6003;
         ChunksetChunk::get_chunkset_data(&buffer, statedump_chunk, &mut unified_log);
@@ -2411,28 +2360,7 @@ mod tests {
 
         let buffer = fs::read(test_path).unwrap();
 
-        let mut unified_log = UnifiedLogCatalogData {
-            catalog: CatalogChunk {
-                chunk_tag: 0,
-                chunk_sub_tag: 0,
-                chunk_data_size: 0,
-                catalog_subsystem_strings_offset: 0,
-                catalog_process_info_entries_offset: 0,
-                number_process_information_entries: 0,
-                catalog_offset_sub_chunks: 0,
-                number_sub_chunks: 0,
-                unknown: Vec::new(),
-                earliest_firehose_timestamp: 0,
-                catalog_uuids: Vec::new(),
-                catalog_subsystem_strings: Vec::new(),
-                catalog_process_info_entries: Vec::new(),
-                catalog_subchunks: Vec::new(),
-            },
-            firehose: Vec::new(),
-            simpledump: Vec::new(),
-            statedump: Vec::new(),
-            oversize: Vec::new(),
-        };
+        let mut unified_log = UnifiedLogCatalogData::default();
 
         let simpledump_chunk = 0x6004;
         ChunksetChunk::get_chunkset_data(&buffer, simpledump_chunk, &mut unified_log);

--- a/src/decoders/location.rs
+++ b/src/decoders/location.rs
@@ -15,6 +15,7 @@ use nom::{
 };
 use std::mem::size_of;
 
+#[derive(Debug, Clone, Default)]
 struct LocationTrackerState {
     distance_filter: f64,
     desired_accuracy: f64,
@@ -629,36 +630,8 @@ mod tests {
 
     #[test]
     fn test_location_tracker_object() {
-        let test_data = LocationTrackerState {
-            distance_filter: 0.0,
-            desired_accuracy: 0.0,
-            updating_location: 0,
-            requesting_location: 0,
-            requesting_ranging: 0,
-            updating_ranging: 0,
-            updating_heading: 0,
-            heading_filter: 0.0,
-            allows_location_prompts: 0,
-            allows_altered_locations: 0,
-            dynamic_accuracy: 0,
-            previous_authorization_status_valid: 0,
-            previous_authorization_status: 0,
-            limits_precision: 0,
-            activity_type: 0,
-            pauses_location_updates: 0,
-            paused: 0,
-            allows_background_updates: 0,
-            shows_background_location: 0,
-            allows_map_correction: 0,
-            batching_location: 0,
-            updating_vehicle_speed: 0,
-            updating_vehicle_heading: 0,
-            match_info: 0,
-            ground_altitude: 0,
-            fusion_info: 0,
-            courtesy_prompt: 0,
-            is_authorized_for_widgets: 0,
-        };
+        let test_data = LocationTrackerState::default();
+
         let result = location_tracker_object(&test_data);
 
         assert_eq!(

--- a/src/header.rs
+++ b/src/header.rs
@@ -13,7 +13,7 @@ use nom::{
     number::complete::{be_u128, le_u32, le_u64},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct HeaderChunk {
     pub chunk_tag: u32,
     pub chunk_sub_tag: u32,
@@ -48,36 +48,8 @@ pub struct HeaderChunk {
 impl HeaderChunk {
     /// Parse the Unified Log tracev3 header data
     pub fn parse_header(data: &[u8]) -> nom::IResult<&[u8], HeaderChunk> {
-        let mut header_chunk = HeaderChunk {
-            chunk_tag: 0,
-            chunk_sub_tag: 0,
-            chunk_data_size: 0,
-            mach_time_numerator: 0,
-            mach_time_denominator: 0,
-            continous_time: 0,
-            unknown_time: 0,
-            unknown: 0,
-            bias_min: 0,
-            daylight_savings: 0,
-            unknown_flags: 0,
-            sub_chunk_tag: 0,
-            sub_chunk_data_size: 0,
-            sub_chunk_continous_time: 0,
-            sub_chunk_tag_2: 0,
-            sub_chunk_tag_data_size_2: 0,
-            unknown_2: 0,
-            unknown_3: 0,
-            build_version_string: String::new(),
-            hardware_model_string: String::new(),
-            sub_chunk_tag_3: 0,
-            sub_chunk_tag_data_size_3: 0,
-            boot_uuid: String::new(),
-            logd_pid: 0,
-            logd_exit_status: 0,
-            sub_chunk_tag_4: 0,
-            sub_chunk_tag_data_size_4: 0,
-            timezone_path: String::new(),
-        };
+        let mut header_chunk = HeaderChunk::default();
+
         let (input, chunk_tag) = take(size_of::<u32>())(data)?;
         let (input, chunk_sub_tag) = take(size_of::<u32>())(input)?;
         let (input, chunk_data_size) = take(size_of::<u64>())(input)?;

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,5 +1,4 @@
 use crate::{
-    catalog::CatalogChunk,
     header::HeaderChunk,
     preamble::LogPreamble,
     unified_log::{LogData, UnifiedLogCatalogData, UnifiedLogData},
@@ -27,28 +26,7 @@ impl Iterator for UnifiedLogIterator {
             oversize: Vec::new(),
         };
 
-        let mut catalog_data = UnifiedLogCatalogData {
-            catalog: CatalogChunk {
-                chunk_tag: 0,
-                chunk_sub_tag: 0,
-                chunk_data_size: 0,
-                catalog_subsystem_strings_offset: 0,
-                catalog_process_info_entries_offset: 0,
-                number_process_information_entries: 0,
-                catalog_offset_sub_chunks: 0,
-                number_sub_chunks: 0,
-                unknown: Vec::new(),
-                earliest_firehose_timestamp: 0,
-                catalog_uuids: Vec::new(),
-                catalog_subsystem_strings: Vec::new(),
-                catalog_process_info_entries: Vec::new(),
-                catalog_subchunks: Vec::new(),
-            },
-            firehose: Vec::new(),
-            simpledump: Vec::new(),
-            statedump: Vec::new(),
-            oversize: Vec::new(),
-        };
+        let mut catalog_data = UnifiedLogCatalogData::default();
 
         let mut input = self.data.as_slice();
         let chunk_preamble_size = 16; // Include preamble size in total chunk size

--- a/src/timesync.rs
+++ b/src/timesync.rs
@@ -12,7 +12,7 @@ use nom::Needed;
 use serde::{Deserialize, Serialize};
 use std::mem::size_of;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct TimesyncBoot {
     pub signature: u16,
     pub header_size: u16,
@@ -26,7 +26,7 @@ pub struct TimesyncBoot {
     pub timesync: Vec<Timesync>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Timesync {
     // Timestamps are in UTC
     pub signature: u32,
@@ -43,18 +43,7 @@ impl TimesyncBoot {
         let mut timesync_data: Vec<TimesyncBoot> = Vec::new();
         let mut input = data;
 
-        let mut timesync_boot = TimesyncBoot {
-            signature: 0,
-            header_size: 0,
-            unknown: 0,
-            boot_uuid: String::new(),
-            timebase_numerator: 0,
-            timebase_denominator: 0,
-            boot_time: 0,
-            timezone_offset_mins: 0,
-            daylight_savings: 0,
-            timesync: Vec::new(),
-        };
+        let mut timesync_boot = TimesyncBoot::default();
 
         while !input.is_empty() {
             let (_, signature) = take(size_of::<u32>())(input)?;

--- a/src/uuidtext.rs
+++ b/src/uuidtext.rs
@@ -12,7 +12,7 @@ use nom::Needed;
 use serde::{Deserialize, Serialize};
 use std::mem::size_of;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct UUIDText {
     pub uuid: String,
     pub signature: u32,
@@ -22,7 +22,7 @@ pub struct UUIDText {
     pub entry_descriptors: Vec<UUIDTextEntry>,
     pub footer_data: Vec<u8>, // Collection of strings containing sender process/library with end of string characters
 }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct UUIDTextEntry {
     pub range_start_offset: u32,
     pub entry_size: u32,
@@ -30,15 +30,7 @@ pub struct UUIDTextEntry {
 impl UUIDText {
     /// Parse the UUID files in uuidinfo directory. Contains the base log message string
     pub fn parse_uuidtext(data: &[u8]) -> nom::IResult<&[u8], UUIDText> {
-        let mut uuidtext_data = UUIDText {
-            uuid: String::new(),
-            signature: 0,
-            unknown_major_version: 0,
-            unknown_minor_version: 0,
-            number_entries: 0,
-            entry_descriptors: Vec::new(),
-            footer_data: Vec::new(),
-        };
+        let mut uuidtext_data = UUIDText::default();
 
         let expected_uuidtext_signature = 0x66778899;
         let (input, signature) = take(size_of::<u32>())(data)?;


### PR DESCRIPTION
Lots of structs are being initialized with default values; therefore,
it makes sense to add the 'Default' derived traits to those structs and
replace default initializations with calls to `default()`.
