### PR TITLE
Change event type and log type to structured enum

### DIFF
--- a/examples/unifiedlog_iterator/src/main.rs
+++ b/examples/unifiedlog_iterator/src/main.rs
@@ -373,8 +373,8 @@ impl OutputWriter {
                 let date_time = Utc.timestamp_nanos(record.time as i64);
                 csv_writer.write_record(&[
                     date_time.to_rfc3339_opts(SecondsFormat::Millis, true),
-                    record.event_type.to_owned(),
-                    record.log_type.to_owned(),
+                    format!("{:?}", record.event_type),
+                    format!("{:?}", record.log_type),
                     record.subsystem.to_owned(),
                     record.thread_id.to_string(),
                     record.pid.to_string(),

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -128,6 +128,7 @@ mod tests {
         filesystem::LogarchiveProvider,
         iterator::nom_bytes,
         parser::{build_log, collect_shared_strings, collect_strings, collect_timesync},
+        unified_log::{EventType, LogType},
     };
     use std::{fs, path::PathBuf};
 
@@ -210,8 +211,8 @@ mod tests {
                 assert_eq!(results[10].pid, 45);
                 assert_eq!(results[10].thread_id, 588);
                 assert_eq!(results[10].category, "device");
-                assert_eq!(results[10].log_type, "Default");
-                assert_eq!(results[10].event_type, "Log");
+                assert_eq!(results[10].log_type, LogType::Default);
+                assert_eq!(results[10].event_type, EventType::Log);
                 assert_eq!(results[10].euid, 0);
                 assert_eq!(results[10].boot_uuid, "80D194AF56A34C54867449D2130D41BB");
                 assert_eq!(results[10].timezone_name, "Pacific");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -178,6 +178,7 @@ mod tests {
     use crate::parser::{
         build_log, collect_shared_strings, collect_strings, collect_timesync, parse_log,
     };
+    use crate::unified_log::{EventType, LogType};
     use std::path::PathBuf;
 
     #[test]
@@ -338,8 +339,8 @@ mod tests {
         assert_eq!(results[10].pid, 45);
         assert_eq!(results[10].thread_id, 588);
         assert_eq!(results[10].category, "device");
-        assert_eq!(results[10].log_type, "Default");
-        assert_eq!(results[10].event_type, "Log");
+        assert_eq!(results[10].log_type, LogType::Default);
+        assert_eq!(results[10].event_type, EventType::Log);
         assert_eq!(results[10].euid, 0);
         assert_eq!(results[10].boot_uuid, "80D194AF56A34C54867449D2130D41BB");
         assert_eq!(results[10].timezone_name, "Pacific");

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -54,32 +54,6 @@ pub enum LogType {
     Loss,
 }
 
-impl LogType {
-    pub fn is_signpost(&self) -> bool {
-        match self {
-            LogType::ProcessSignpostEvent
-            | LogType::ProcessSignpostStart
-            | LogType::ProcessSignpostEnd
-            | LogType::SystemSignpostEvent
-            | LogType::SystemSignpostStart
-            | LogType::SystemSignpostEnd
-            | LogType::ThreadSignpostEvent
-            | LogType::ThreadSignpostStart
-            | LogType::ThreadSignpostEnd => true,
-            LogType::Debug
-            | LogType::Info
-            | LogType::Default
-            | LogType::Error
-            | LogType::Fault
-            | LogType::Create
-            | LogType::Useraction
-            | LogType::Simpledump
-            | LogType::Statedump
-            | LogType::Loss => false,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum EventType {
     Unknown,

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -54,6 +54,32 @@ pub enum LogType {
     Loss,
 }
 
+impl LogType {
+    pub fn is_signpost(&self) -> bool {
+        match self {
+            LogType::ProcessSignpostEvent
+            | LogType::ProcessSignpostStart
+            | LogType::ProcessSignpostEnd
+            | LogType::SystemSignpostEvent
+            | LogType::SystemSignpostStart
+            | LogType::SystemSignpostEnd
+            | LogType::ThreadSignpostEvent
+            | LogType::ThreadSignpostStart
+            | LogType::ThreadSignpostEnd => true,
+            LogType::Debug
+            | LogType::Info
+            | LogType::Default
+            | LogType::Error
+            | LogType::Fault
+            | LogType::Create
+            | LogType::Useraction
+            | LogType::Simpledump
+            | LogType::Statedump
+            | LogType::Loss => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum EventType {
     Unknown,

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -11,7 +11,7 @@ use macos_unifiedlogs::{
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_shared_strings, collect_strings, collect_timesync, parse_log},
     traits::FileProvider,
-    unified_log::{LogData, UnifiedLogData},
+    unified_log::{EventType, LogData, LogType, UnifiedLogData},
 };
 use regex::Regex;
 
@@ -86,8 +86,8 @@ fn test_big_sur_livedata() {
             );
             assert_eq!(results.subsystem, String::new());
             assert_eq!(results.category, String::new());
-            assert_eq!(results.event_type, "Log");
-            assert_eq!(results.log_type, "Info");
+            assert_eq!(results.event_type, EventType::Log);
+            assert_eq!(results.log_type, LogType::Info);
             assert_eq!(results.process, "/kernel");
             assert_eq!(results.time, 1642304801596413351.0);
             assert_eq!(results.boot_uuid, "A2A9017676CF421C84DC9BBD6263FEE7");
@@ -133,8 +133,8 @@ fn test_build_log_big_sur() {
     assert_eq!(results[0].pid, 105);
     assert_eq!(results[0].thread_id, 670);
     assert_eq!(results[0].category, "default");
-    assert_eq!(results[0].log_type, "Default");
-    assert_eq!(results[0].event_type, "Log");
+    assert_eq!(results[0].log_type, LogType::Default);
+    assert_eq!(results[0].event_type, EventType::Log);
     assert_eq!(results[0].euid, 0);
     assert_eq!(results[0].boot_uuid, "AACFB573E87545CE98B893D132766A46");
     assert_eq!(results[0].timezone_name, "Pacific");
@@ -219,25 +219,25 @@ fn test_parse_all_logs_big_sur() {
             found_precision_string = true;
         }
 
-        if logs.event_type == "Statedump" {
+        if logs.event_type == EventType::Statedump {
             statedump_count += 1;
-        } else if logs.event_type == "Signpost" {
+        } else if logs.event_type == EventType::Signpost {
             signpost_count += 1;
-        } else if logs.log_type == "Default" {
+        } else if logs.log_type == LogType::Default {
             default_type += 1;
-        } else if logs.log_type == "Info" {
+        } else if logs.log_type == LogType::Info {
             info_type += 1;
-        } else if logs.log_type == "Error" {
+        } else if logs.log_type == LogType::Error {
             error_type += 1
-        } else if logs.log_type == "Create" {
+        } else if logs.log_type == LogType::Create {
             create_type += 1;
-        } else if logs.log_type == "Debug" {
+        } else if logs.log_type == LogType::Debug {
             debug_type += 1;
-        } else if logs.log_type == "Useraction" {
+        } else if logs.log_type == LogType::Useraction {
             useraction_type += 1;
-        } else if logs.log_type == "Fault" {
+        } else if logs.log_type == LogType::Fault {
             fault_type += 1;
-        } else if logs.event_type == "Loss" {
+        } else if logs.event_type == EventType::Loss {
             loss_type += 1;
         }
 
@@ -245,7 +245,10 @@ fn test_parse_all_logs_big_sur() {
             string_count += 1;
         }
 
-        if logs.raw_message.is_empty() && logs.message.is_empty() && logs.event_type != "Loss" {
+        if logs.raw_message.is_empty()
+            && logs.message.is_empty()
+            && logs.event_type != EventType::Loss
+        {
             empty_format_count += 1
         }
 
@@ -314,7 +317,7 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
     // Check all logs that contain the word "network"
     for logs in &log_data_vec {
         if logs.message.to_lowercase().contains("network") {
-            if logs.log_type == "Default" {
+            if logs.log_type == LogType::Default {
                 default_type += 1;
                 if logs
                     .message
@@ -338,21 +341,23 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
                      */
                     network_message_uuid = true;
                 }
-            } else if logs.log_type == "Info" {
+            } else if logs.log_type == LogType::Info {
                 info_type += 1;
-            } else if logs.log_type == "Error" {
+            } else if logs.log_type == LogType::Error {
                 error_type += 1
-            } else if logs.log_type == "Create" {
+            } else if logs.log_type == LogType::Create {
                 create_type += 1;
                 // We are basing these counts on the Cosole.app tool
                 // Console.app skips Activity event logs
                 continue;
-            } else if logs.log_type == String::new() {
+            } else if logs.event_type == EventType::Simpledump
+                || logs.event_type == EventType::Statedump
+            {
                 // We are basing these counts on the Cosole.app tool
                 // Console.app skips Simple and State dump event logs
                 state_simple_dump += 1;
                 continue;
-            } else if logs.log_type.contains("Signpost") {
+            } else if logs.log_type.is_signpost() {
                 // We are basing these counts on the Cosole.app tool
                 // Console.app skips Signpost event logs
                 signpost += 1;
@@ -572,15 +577,15 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_special_file() {
     let mut error = 0;
 
     for result in results {
-        if result.event_type == "Statedump" {
+        if result.event_type == EventType::Statedump {
             statedump += 1;
-        } else if result.log_type == "Default" {
+        } else if result.log_type == LogType::Default {
             default += 1;
-        } else if result.log_type == "Fault" {
+        } else if result.log_type == LogType::Fault {
             fault += 1;
-        } else if result.log_type == "Info" {
+        } else if result.log_type == LogType::Info {
             info += 1;
-        } else if result.log_type == "Error" {
+        } else if result.log_type == LogType::Error {
             error += 1;
         }
     }

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -22,6 +22,30 @@ fn collect_logs(provider: &dyn FileProvider) -> Vec<UnifiedLogData> {
         .collect()
 }
 
+fn is_signpost(log_type: LogType) -> bool {
+    match log_type {
+        LogType::ProcessSignpostEvent
+        | LogType::ProcessSignpostStart
+        | LogType::ProcessSignpostEnd
+        | LogType::SystemSignpostEvent
+        | LogType::SystemSignpostStart
+        | LogType::SystemSignpostEnd
+        | LogType::ThreadSignpostEvent
+        | LogType::ThreadSignpostStart
+        | LogType::ThreadSignpostEnd => true,
+        LogType::Debug
+        | LogType::Info
+        | LogType::Default
+        | LogType::Error
+        | LogType::Fault
+        | LogType::Create
+        | LogType::Useraction
+        | LogType::Simpledump
+        | LogType::Statedump
+        | LogType::Loss => false,
+    }
+}
+
 #[test]
 fn test_parse_log_big_sur() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -357,7 +381,7 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
                 // Console.app skips Simple and State dump event logs
                 state_simple_dump += 1;
                 continue;
-            } else if logs.log_type.is_signpost() {
+            } else if is_signpost(logs.log_type) {
                 // We are basing these counts on the Cosole.app tool
                 // Console.app skips Signpost event logs
                 signpost += 1;

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -10,7 +10,7 @@ use macos_unifiedlogs::{
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_shared_strings, collect_strings, collect_timesync, parse_log},
     traits::FileProvider,
-    unified_log::UnifiedLogData,
+    unified_log::{EventType, LogType, UnifiedLogData},
 };
 use regex::Regex;
 
@@ -79,8 +79,8 @@ fn test_build_log_high_sierra() {
     assert_eq!(results[0].pid, 59);
     assert_eq!(results[0].thread_id, 622);
     assert_eq!(results[0].category, "default");
-    assert_eq!(results[0].log_type, "Default");
-    assert_eq!(results[0].event_type, "Log");
+    assert_eq!(results[0].log_type, LogType::Default);
+    assert_eq!(results[0].event_type, EventType::Log);
     assert_eq!(results[0].euid, 0);
     assert_eq!(results[0].boot_uuid, "30774817CF1549B0920E1A8E17D47AB5");
     assert_eq!(results[0].timezone_name, "Pacific");
@@ -130,8 +130,8 @@ fn test_build_log_complex_format_high_sierra() {
             assert_eq!(result.pid, 580);
             assert_eq!(result.thread_id, 8759);
             assert_eq!(result.category, "persistentTimer.com.apple.CalendarNotification.EKTravelEngine.periodicRefreshTimer");
-            assert_eq!(result.log_type, "Default");
-            assert_eq!(result.event_type, "Log");
+            assert_eq!(result.log_type, LogType::Default);
+            assert_eq!(result.event_type, EventType::Log);
             assert_eq!(result.euid, 501);
             assert_eq!(result.boot_uuid, "30774817CF1549B0920E1A8E17D47AB5");
             assert_eq!(result.timezone_name, "Pacific");

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -11,7 +11,7 @@ use macos_unifiedlogs::{
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_shared_strings, collect_strings, collect_timesync, parse_log},
     traits::FileProvider,
-    unified_log::{LogData, UnifiedLogData},
+    unified_log::{EventType, LogData, LogType, UnifiedLogData},
 };
 use regex::Regex;
 
@@ -85,8 +85,8 @@ fn test_build_log_monterey() {
     assert_eq!(results[0].pid, 0);
     assert_eq!(results[0].thread_id, 2241);
     assert_eq!(results[0].category, "");
-    assert_eq!(results[0].log_type, "Error");
-    assert_eq!(results[0].event_type, "Log");
+    assert_eq!(results[0].log_type, LogType::Error);
+    assert_eq!(results[0].event_type, EventType::Log);
     assert_eq!(results[0].euid, 0);
     assert_eq!(results[0].boot_uuid, "17AB576950394796B7F3CD2C157F4A2F");
     assert_eq!(results[0].timezone_name, "New_York");
@@ -161,7 +161,9 @@ fn test_parse_all_logs_monterey() {
             string_count += 1;
         }
 
-        if logs.message.contains("MTUtilities: WorldClockWidget:") && logs.log_type == "Default" {
+        if logs.message.contains("MTUtilities: WorldClockWidget:")
+            && logs.log_type == LogType::Default
+        {
             mutilities_worldclock += 1;
         }
         if logs.message.contains("MTUtilities: Returning widget") {


### PR DESCRIPTION
Hi

I think it would make a better interface if we used enums to represent the event type and log type. It also should be more efficient since we are using a pair of enum instead of a string.

We can also more accurately represent the possible states by nesting the log type in the enum variant where it is applicable.

This does make some assumptions about the combination of event type and log type but I think it is correct.

Any feedback is appreciated