### PR TITLE
StateDump Protobuf parsing support

### DIFF
--- a/.changes/unreleased/Added-20250225-004526.yaml
+++ b/.changes/unreleased/Added-20250225-004526.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support for parsing StateDump Protobuf data
+time: 2025-02-25T00:45:26.095821273-05:00

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ regex = "1.11.1"
 base64 = "0.22.1"
 chrono = "0.4.39"
 walkdir = "2.5.0"
+sunlight = "0.1.1"
 
 [dev-dependencies]
 simplelog = "0.12.2"

--- a/README.md
+++ b/README.md
@@ -30,18 +30,10 @@ Data that is currently extracted includes:
 
 ## Running
 
-Four example binaries are available.
+An example binary is available to download
 
-- `unifiedlog_parser` - Can parse all logs into a single CSV file. It can also
-  be run on a live system. The resulting CSV file will likely be quite large
-- `unifiedlog_iterator` - Can parse all logs into a single CSV file using an
-  iterator. May use less memory than the other example files. It can also be run
-  on a live system. The resulting CSV file will likely be quite large
-- `unifiedlog_parser_json` - Can parse all logs into JSON files. It can also be
-  run on a live system. Each log file will be parsed to a single JSON file.
-- `parse_tracev3` - Can parse a single tracev3 file without any timesync or
-  uuidtext files to JSON. However, without the uuidtext or timesync files the
-  resulting JSON file will be incomplete.
+- `unifiedlog_iterator` - Can parse a logarchive into a JSOL or CSV file. It can also run
+  on a live system. The output file will be quite large
 
 ## Limitations
 

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -235,7 +235,11 @@ fn test_parse_all_logs_big_sur() {
             invalid_shared_string_offsets += 1;
         } else if logs.message.contains("Unsupported Statedump object") {
             statedump_custom_objects += 1;
-        } else if logs.message.contains("Statedump Protocol Buffer") {
+        } else if logs.message.contains("Failed to parse StateDump protobuf")
+            || logs
+                .message
+                .contains("Failed to serialize Protobuf HashMap")
+        {
             statedump_protocol_buffer += 1;
         } else if logs.message
             == r##"#32EC4B64 [AssetCacheLocatorService.queue] sending POST [327]{"locator-tag":"#32ec4b64","local-addresses":["192.168.101.144"],"ranked-results":true,"locator-software":[{"build":"20G224","type":"system","name":"macOS","version":"11.6.1"},{"id":"com.apple.AssetCacheLocatorService","executable":"AssetCacheLocatorService","type":"bundle","name":"AssetCacheLocatorService","version":"118"}]} to https://lcdn-locator.apple.com/lcdn/locate"##
@@ -285,7 +289,7 @@ fn test_parse_all_logs_big_sur() {
     assert_eq!(invalid_offsets, 54);
     assert_eq!(invalid_shared_string_offsets, 0);
     assert_eq!(statedump_custom_objects, 2);
-    assert_eq!(statedump_protocol_buffer, 3);
+    assert_eq!(statedump_protocol_buffer, 0);
     assert_eq!(found_precision_string, true);
 
     assert_eq!(statedump_count, 322);

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -297,7 +297,11 @@ fn test_parse_all_logs_high_sierra() {
         if logs.message.contains("Unsupported Statedump object") {
             statedump_custom_objects += 1;
         }
-        if logs.message.contains("Statedump Protocol Buffer") {
+        if logs.message.contains("Failed to parse StateDump protobuf")
+            || logs
+                .message
+                .contains("Failed to serialize Protobuf HashMap")
+        {
             statedump_protocol_buffer += 1;
         }
     }
@@ -305,5 +309,5 @@ fn test_parse_all_logs_high_sierra() {
     assert_eq!(invalid_offsets, 3);
     assert_eq!(invalid_shared_string_offsets, 0);
     assert_eq!(statedump_custom_objects, 2);
-    assert_eq!(statedump_protocol_buffer, 1);
+    assert_eq!(statedump_protocol_buffer, 0);
 }

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -153,7 +153,11 @@ fn test_parse_all_logs_monterey() {
         if logs.message.contains("Unsupported Statedump object") {
             statedump_custom_objects += 1;
         }
-        if logs.message.contains("Statedump Protocol Buffer") {
+        if logs.message.contains("Failed to parse StateDump protobuf")
+            || logs
+                .message
+                .contains("Failed to serialize Protobuf HashMap")
+        {
             statedump_protocol_buffer += 1;
         }
 
@@ -186,7 +190,7 @@ fn test_parse_all_logs_monterey() {
     assert_eq!(invalid_offsets, 60);
     assert_eq!(invalid_shared_string_offsets, 309);
     assert_eq!(statedump_custom_objects, 2);
-    assert_eq!(statedump_protocol_buffer, 9);
+    assert_eq!(statedump_protocol_buffer, 0);
     assert_eq!(string_count, 28196); // Accurate count based on log raw-dump -a <monterey.logarchive> | grep "format:\s*%s$" | sort | uniq -c | sort -n
     assert_eq!(mutilities_worldclock, 57);
     assert_eq!(mutililties_return, 71);


### PR DESCRIPTION
This PR adds support for parsing Protobuf data in StateDump log entries. It uses the small [sunlight](https://github.com/puffyCid/sunlight) library to parse the data