### PR TITLE
Support for DNS and NWI log objects

### DIFF
--- a/.changes/unreleased/Added-20250605-020237.yaml
+++ b/.changes/unreleased/Added-20250605-020237.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support for parsing DNS info objects
+time: 2025-06-05T02:02:37.742677527-04:00

--- a/.changes/unreleased/Added-20250605-020251.yaml
+++ b/.changes/unreleased/Added-20250605-020251.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support for parsing Network Interface (NWI) objects
+time: 2025-06-05T02:02:51.635917684-04:00

--- a/.changes/unreleased/Changed-20250605-020446.yaml
+++ b/.changes/unreleased/Changed-20250605-020446.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'Better logging when encountering log messages that do not follow printf formatting. Ex: printf(%u, "message") instead of printf(%u, 10)'
+time: 2025-06-05T02:04:46.847107758-04:00

--- a/.changes/unreleased/Fixed-20250605-020350.yaml
+++ b/.changes/unreleased/Fixed-20250605-020350.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Added new private string formatting id
+time: 2025-06-05T02:03:50.747631683-04:00

--- a/.changes/unreleased/Fixed-20250605-020516.yaml
+++ b/.changes/unreleased/Fixed-20250605-020516.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Added additional DNS record type (NULL)
+time: 2025-06-05T02:05:16.887208798-04:00

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ byteorder = "1.5.0"
 plist = "1.7.1"
 regex = "1.11.1"
 base64 = "0.22.1"
-chrono = "0.4.40"
+chrono = "0.4.41"
 walkdir = "2.5.0"
 sunlight = "0.1.1"
 
 [dev-dependencies]
-chrono = "0.4.40"
-criterion = "0.5.1"
-anyhow = "1.0.97"
+chrono = "0.4.41"
+criterion = "0.6.0"
+anyhow = "1.0.98"
 test-case = "3.3"
 
 [[bench]]

--- a/src/chunks/statedump.rs
+++ b/src/chunks/statedump.rs
@@ -151,8 +151,8 @@ impl Statedump {
             "CLClientManagerStateTracker" => location::get_state_tracker_data(object_data),
             "CLLocationManagerStateTracker" => location::get_location_tracker_state(object_data),
             "DNS Configuration" => config::get_dns_config(object_data),
+            "Network information" => config::get_network_interface(object_data),
             _ => {
-                println!("{name}");
                 return format!(
                     "Unsupported Statedump object: {name}-{}",
                     encode_standard(object_data)

--- a/src/chunks/statedump.rs
+++ b/src/chunks/statedump.rs
@@ -5,7 +5,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use crate::decoders::location;
+use crate::decoders::{config, location};
 use crate::util::{clean_uuid, encode_standard, extract_string};
 use log::{error, info};
 use nom::bytes::complete::take;
@@ -150,7 +150,9 @@ impl Statedump {
             "CLDaemonStatusStateTracker" => location::get_daemon_status_tracker(object_data),
             "CLClientManagerStateTracker" => location::get_state_tracker_data(object_data),
             "CLLocationManagerStateTracker" => location::get_location_tracker_state(object_data),
+            "DNS Configuration" => config::get_dns_config(object_data),
             _ => {
+                println!("{name}");
                 return format!(
                     "Unsupported Statedump object: {name}-{}",
                     encode_standard(object_data)

--- a/src/decoders/config.rs
+++ b/src/decoders/config.rs
@@ -86,50 +86,18 @@ fn parse_dns_config<'a>(
 
     // Now assemble our message!
     let mut message = String::from("DNS Configuration\n");
-    for (key, entry) in resolvers.iter().enumerate() {
-        let mut resolver_message = format!("resolver #{key}\n");
-        for (index, value) in entry.search_domains.iter().enumerate() {
-            resolver_message += &format!("  search domain[{index}] : {value}\n");
-        }
-        for (index, value) in entry.nameservers.iter().enumerate() {
-            resolver_message += &format!("  nameserver[{index}] : {value}\n");
-        }
-
-        if entry.if_index != 0 && !entry.if_index_value.is_empty() {
-            resolver_message += &format!(
-                "  if_index : {} ({})\n",
-                entry.if_index, entry.if_index_value
-            );
-        }
-
-        if !entry.domain.is_empty() {
-            resolver_message += &format!("  domain   : {}\n", entry.domain);
-        }
-        if !entry.options.is_empty() {
-            resolver_message += &format!("  options  : {}\n", entry.options);
-        }
-        if entry.timeout != 0 {
-            resolver_message += &format!("  timeout  : {}\n", entry.timeout);
-        }
-
-        resolver_message += &format!(
-            "  flags    : {:#010x?} {}\n",
-            entry.dns_flags, entry.dns_flags_string
-        );
-        resolver_message += &format!(
-            "  reach    : {:#010x?} {}\n",
-            entry.reach, entry.reach_string
-        );
-        if entry.order != 0 {
-            resolver_message += &format!("  order    : {}\n", entry.order);
-        }
-        resolver_message += &format!("  config id: {}\n\n", entry.config_id);
-
-        message += &resolver_message;
-    }
+    message += &assemble_message(&message, &resolvers);
 
     message += "DNS configuration (for scoped queries)\n\n";
-    for (key, entry) in scopes.iter().enumerate() {
+    message += &assemble_message(&message, &scopes);
+
+    Ok((remaining, message))
+}
+
+/// Combine our `DnsConfigs` into single message
+fn assemble_message(log_message: &str, configs: &[DnsConfig]) -> String {
+    let mut message = log_message.to_string();
+    for (key, entry) in configs.iter().enumerate() {
         let mut resolver_message = format!("resolver #{key}\n");
         for (index, value) in entry.search_domains.iter().enumerate() {
             resolver_message += &format!("  search domain[{index}] : {value}\n");
@@ -171,7 +139,7 @@ fn parse_dns_config<'a>(
         message += &resolver_message;
     }
 
-    Ok((remaining, message))
+    message
 }
 
 #[derive(Debug, Default)]

--- a/src/decoders/config.rs
+++ b/src/decoders/config.rs
@@ -1,0 +1,471 @@
+// Copyright 2022 Mandiant, Inc. All Rights Reserved
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and limitations under the License.
+
+use super::network::{get_ip_four, get_ip_six};
+use crate::util::{encode_standard, extract_string};
+use log::warn;
+use nom::{
+    bytes::complete::take,
+    number::complete::{be_u32, be_u64},
+};
+
+/// Parse DNS configuration. Can view live data with macOS command `scutil --dns`. This info is also logged to the Unified Log
+pub(crate) fn get_dns_config(data: &[u8]) -> nom::IResult<&[u8], String> {
+    let (input, resolver_count) = be_u32(data)?;
+
+    // Seen only zero
+    let (input, _unknown) = take(8_u8)(input)?;
+    let (input, scope_count) = be_u32(input)?;
+    // Seen only zero
+    let (input, _unknown) = take(8_u8)(input)?;
+
+    // Seen 0x5D8D7152
+    let (input, _unknown) = take(4_u8)(input)?;
+    // Seen 0x0
+    let (input, _unknown) = take(16_u8)(input)?;
+
+    // Seen 0x85C73301
+    let (input, _unknown) = take(4_u8)(input)?;
+
+    // Seen 0x000005EC. Maybe a size?
+    let (input, _unknown) = take(4_u8)(input)?;
+
+    // Seen 0x00000070. Maybe a size?
+    let (input, _unknown) = take(4_u8)(input)?;
+
+    let total_count = resolver_count + scope_count;
+    let (_, message) = parse_dns_config(input, &total_count)?;
+
+    Ok((input, message))
+}
+
+/// Parse the DNS config data and assemble message
+fn parse_dns_config<'a>(
+    data: &'a [u8],
+    resolver_scope_count: &u32,
+) -> nom::IResult<&'a [u8], String> {
+    let mut count = 0;
+    let mut remaining = data;
+    let mut resolvers = Vec::new();
+    let mut scopes = Vec::new();
+    while count < *resolver_scope_count {
+        // 1 = DNS Resolver. 2 = DNS Scope. Both appear to have same format
+        let (input, resolver_or_scope) = be_u32(remaining)?;
+        let (input, size) = be_u32(input)?;
+
+        let adjust = 8;
+        if adjust > size {
+            break;
+        }
+        // Size includes `resolver_or_scope` amd `size` value
+        let (input, config_data) = take(size - adjust)(input)?;
+        remaining = input;
+
+        match resolver_or_scope {
+            1 => resolvers.push(parse_dns_resolver(config_data)?.1),
+            2 => scopes.push(parse_dns_resolver(config_data)?.1),
+            _ => {
+                warn!(
+                    "[macos-unifiedlogs] Unknown DNS config type. Neither resolver or scope: {resolver_or_scope}"
+                );
+                return Ok((
+                    remaining,
+                    format!(
+                        "Unknown DNS config type. Neither resolver or scope: {resolver_or_scope}: {}",
+                        encode_standard(data)
+                    ),
+                ));
+            }
+        };
+        count += 1;
+    }
+
+    // Now assemble our message!
+    let mut message = String::from("DNS Configuration\n");
+    for (key, entry) in resolvers.iter().enumerate() {
+        let mut resolver_message = format!("resolver #{key}\n");
+        for (index, value) in entry.search_domains.iter().enumerate() {
+            resolver_message += &format!("  search domain[{index}] : {value}\n");
+        }
+        for (index, value) in entry.nameservers.iter().enumerate() {
+            resolver_message += &format!("  nameserver[{index}] : {value}\n");
+        }
+
+        if entry.if_index != 0 && !entry.if_index_value.is_empty() {
+            resolver_message += &format!(
+                "  if_index : {} ({})\n",
+                entry.if_index, entry.if_index_value
+            );
+        }
+
+        if !entry.domain.is_empty() {
+            resolver_message += &format!("  domain   : {}\n", entry.domain);
+        }
+        if !entry.options.is_empty() {
+            resolver_message += &format!("  options  : {}\n", entry.options);
+        }
+        if entry.timeout != 0 {
+            resolver_message += &format!("  timeout  : {}\n", entry.timeout);
+        }
+
+        resolver_message += &format!(
+            "  flags    : {:#010x?} {}\n",
+            entry.dns_flags, entry.dns_flags_string
+        );
+        resolver_message += &format!(
+            "  reach    : {:#010x?} {}\n",
+            entry.reach, entry.reach_string
+        );
+        if entry.order != 0 {
+            resolver_message += &format!("  order    : {}\n", entry.order);
+        }
+        resolver_message += &format!("  config id: {}\n\n", entry.config_id);
+
+        message += &resolver_message;
+    }
+
+    message += "DNS configuration (for scoped queries)\n\n";
+    for (key, entry) in scopes.iter().enumerate() {
+        let mut resolver_message = format!("resolver #{key}\n");
+        for (index, value) in entry.search_domains.iter().enumerate() {
+            resolver_message += &format!("  search domain[{index}] : {value}\n");
+        }
+        for (index, value) in entry.nameservers.iter().enumerate() {
+            resolver_message += &format!("  nameserver[{index}] : {value}\n");
+        }
+
+        if entry.if_index != 0 && !entry.if_index_value.is_empty() {
+            resolver_message += &format!(
+                "  if_index : {} ({})\n",
+                entry.if_index, entry.if_index_value
+            );
+        }
+
+        if !entry.domain.is_empty() {
+            resolver_message += &format!("  domain   : {}\n", entry.domain);
+        }
+        if !entry.options.is_empty() {
+            resolver_message += &format!("  options  : {}\n", entry.options);
+        }
+        if entry.timeout != 0 {
+            resolver_message += &format!("  timeout  : {}\n", entry.timeout);
+        }
+
+        resolver_message += &format!(
+            "  flags    : {:#010x?} {}\n",
+            entry.dns_flags, entry.dns_flags_string
+        );
+        resolver_message += &format!(
+            "  reach    : {:#010x?} {}\n",
+            entry.reach, entry.reach_string
+        );
+        if entry.order != 0 {
+            resolver_message += &format!("  order    : {}\n", entry.order);
+        }
+        resolver_message += &format!("  config id: {}\n\n", entry.config_id);
+
+        message += &resolver_message;
+    }
+
+    Ok((remaining, message))
+}
+
+#[derive(Debug, Default)]
+struct DnsConfig {
+    nameservers: Vec<String>,
+    search_domains: Vec<String>,
+    timeout: u32,
+    order: u32,
+    if_index: u32,
+    if_index_value: String,
+    dns_flags: u32,
+    dns_flags_string: String,
+    reach: u32,
+    reach_string: String,
+    config_id: String,
+    options: String,
+    domain: String,
+    unknown: String,
+}
+
+/// Parse DNS resolver data
+fn parse_dns_resolver(data: &[u8]) -> nom::IResult<&[u8], DnsConfig> {
+    // Seen 0x0
+    let (input, _unknown) = take(8_u8)(data)?;
+    let (input, _nameserver_count) = be_u32(input)?;
+
+    // Seen 0x0. 3 flags? (each 4 bytes?)
+    let (input, _unknown) = take(12_u8)(input)?;
+    let (input, _search_domain_count) = be_u32(input)?;
+
+    // Seen 0x0. More flags?
+    let (input, _unknown) = take(28_u8)(input)?;
+
+    let (input, timeout) = be_u32(input)?;
+    let (input, order) = be_u32(input)?;
+    let (input, if_index) = be_u32(input)?;
+    let (input, dns_flags) = be_u32(input)?;
+    let (input, reach) = be_u32(input)?;
+
+    // Seen 0x0. More flags?
+    let (input, _unknown) = take(20_u8)(input)?;
+    // Size for remaining bytes
+    let (input, _size) = be_u32(input)?;
+
+    // remaining bytes is variety of config options
+    let min_size = 10;
+    let mut remaining = input;
+    let mut config = DnsConfig {
+        timeout,
+        order,
+        if_index,
+        dns_flags,
+        reach,
+        ..Default::default()
+    };
+    if dns_flags == 6 {
+        config.dns_flags_string = String::from("(Request A records, Request AAAA records)");
+    }
+    if reach == 0 {
+        config.reach_string = String::from("(Not Reachable)")
+    } else if reach == 0x00020002 {
+        config.reach_string = String::from("(Reachable, Directly Reachable Address)")
+    }
+    while remaining.len() > min_size {
+        // Option types:
+        // 0xc - search domain
+        // 0xb - nameserver
+        // 0x10 - if_index value
+        // 0xa - domain
+        // 0xe - options
+        // 0xf - config id
+        let (input, option_type) = be_u32(remaining)?;
+        let (input, option_size) = be_u32(input)?;
+        let adjust: u32 = 8;
+        if adjust > option_size {
+            break;
+        }
+
+        // `option_size` includes `option_type` and `option_size`
+        let (input, option_data) = take(option_size - adjust)(input)?;
+        remaining = input;
+        match option_type {
+            0xc => config.search_domains.push(extract_string(option_data)?.1),
+            0x10 => config.if_index_value = extract_string(option_data)?.1,
+            0xb => config.nameservers.push(parse_nameserver(option_data)?.1),
+            0xf => config.config_id = extract_string(option_data)?.1,
+            0xa => config.domain = extract_string(option_data)?.1,
+            0xe => config.options = extract_string(option_data)?.1,
+            _ => {
+                warn!("[macos-unifiedlogs] Unknown DNS option type: {option_type}");
+                config.unknown = format!(
+                    "Unknown DNS option type: {option_type}: {}",
+                    encode_standard(data)
+                );
+                return Ok((remaining, config));
+            }
+        }
+    }
+
+    Ok((input, config))
+}
+
+/// Parse nameserver IPv4 or IPv6
+fn parse_nameserver(data: &[u8]) -> nom::IResult<&[u8], String> {
+    let ipv4 = 16;
+    let ipv6 = 28;
+    let (input, value) = if data.len() == ipv4 {
+        // Flags?
+        let (input, _unknown) = be_u32(data)?;
+        let (input, ip) = get_ip_four(input)?;
+        (input, ip.to_string())
+    } else if data.len() == ipv6 {
+        // Flags?
+        let (input, _unknown) = be_u64(data)?;
+        let (input, ip) = get_ip_six(input)?;
+        (input, ip.to_string())
+    } else {
+        warn!("[macos-unifiedlogs] Unknown nameserver data type");
+        (
+            data,
+            format!("Unknown nameserver data type: {}", encode_standard(data)),
+        )
+    };
+
+    Ok((input, value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_dns_config, parse_dns_config, parse_dns_resolver, parse_nameserver};
+
+    #[test]
+    fn test_get_dns_config() {
+        let test_data = [
+            0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 93, 141, 113,
+            82, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 133, 199, 51, 1, 0, 0, 5, 236, 0,
+            0, 0, 112, 0, 0, 0, 1, 0, 0, 0, 212, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 6, 0, 2, 0,
+            2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0,
+            12, 0, 0, 0, 12, 108, 97, 110, 0, 0, 0, 0, 16, 0, 0, 0, 12, 101, 110, 48, 0, 0, 0, 0,
+            11, 0, 0, 0, 24, 16, 2, 0, 0, 192, 168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0,
+            0, 0, 36, 28, 30, 0, 0, 0, 0, 0, 0, 253, 169, 223, 235, 210, 116, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 20, 68, 101, 102, 97, 117, 108, 116, 58, 32,
+            48, 0, 0, 0, 0, 0, 2, 0, 0, 0, 248, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 16, 6, 0, 2,
+            0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 140, 0, 0,
+            0, 12, 0, 0, 0, 12, 108, 97, 110, 0, 0, 0, 0, 16, 0, 0, 0, 12, 101, 110, 48, 0, 0, 0,
+            0, 11, 0, 0, 0, 24, 16, 2, 0, 0, 192, 168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11,
+            0, 0, 0, 36, 28, 30, 0, 0, 0, 0, 0, 0, 253, 169, 223, 235, 210, 116, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 56, 83, 99, 111, 112, 101, 100, 58, 32,
+            52, 52, 70, 56, 67, 67, 50, 68, 45, 67, 65, 66, 51, 45, 52, 57, 69, 65, 45, 66, 50, 67,
+            48, 45, 69, 66, 51, 51, 68, 57, 50, 57, 53, 67, 67, 65, 32, 48, 0, 0, 0, 0, 0, 1, 0, 0,
+            0, 168, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 5, 0, 4, 147, 224, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 60, 0, 0, 0, 10, 0, 0, 0, 16, 108, 111,
+            99, 97, 108, 0, 0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0,
+            0, 15, 0, 0, 0, 28, 77, 117, 108, 116, 105, 99, 97, 115, 116, 32, 68, 78, 83, 58, 32,
+            48, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 4, 148, 168, 0, 0, 0, 0, 0, 0, 0, 6,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 76, 0,
+            0, 0, 10, 0, 0, 0, 32, 50, 53, 52, 46, 49, 54, 57, 46, 105, 110, 45, 97, 100, 100, 114,
+            46, 97, 114, 112, 97, 0, 0, 0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0,
+            0, 0, 0, 0, 0, 15, 0, 0, 0, 28, 77, 117, 108, 116, 105, 99, 97, 115, 116, 32, 68, 78,
+            83, 58, 32, 49, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 176, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 4, 149, 112, 0, 0, 0, 0,
+            0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 68, 0, 0, 0, 10, 0, 0, 0, 24, 56, 46, 101, 46, 102, 46, 105, 112, 54, 46, 97,
+            114, 112, 97, 0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0, 0,
+            15, 0, 0, 0, 28, 77, 117, 108, 116, 105, 99, 97, 115, 116, 32, 68, 78, 83, 58, 32, 50,
+            0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 176, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 4, 150, 56, 0, 0, 0, 0, 0, 0, 0, 6, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 0, 0,
+            0, 10, 0, 0, 0, 24, 57, 46, 101, 46, 102, 46, 105, 112, 54, 46, 97, 114, 112, 97, 0, 0,
+            0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 28, 77,
+            117, 108, 116, 105, 99, 97, 115, 116, 32, 68, 78, 83, 58, 32, 51, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 176, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 5, 0, 4, 151, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 0, 0, 0, 10, 0, 0, 0, 24,
+            97, 46, 101, 46, 102, 46, 105, 112, 54, 46, 97, 114, 112, 97, 0, 0, 0, 0, 0, 14, 0, 0,
+            0, 16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 28, 77, 117, 108, 116,
+            105, 99, 97, 115, 116, 32, 68, 78, 83, 58, 32, 52, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+            176, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 5, 0, 4, 151, 200, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 0, 0, 0, 10, 0, 0, 0, 24, 98, 46, 101,
+            46, 102, 46, 105, 112, 54, 46, 97, 114, 112, 97, 0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109,
+            100, 110, 115, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 28, 77, 117, 108, 116, 105, 99, 97,
+            115, 116, 32, 68, 78, 83, 58, 32, 53, 0, 0, 0, 0,
+        ];
+
+        let (_, result) = get_dns_config(&test_data).unwrap();
+        assert!(result.contains("  domain   : 254.169.in-addr.arpa\n"));
+        assert!(result.contains("config id: Scoped: 44F8CC2D-CAB3-49EA-B2C0-EB33D9295CCA 0"))
+    }
+
+    #[test]
+    fn test_parse_nameserver() {
+        let test_data = [16, 2, 0, 0, 192, 168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0];
+        let (_, result) = parse_nameserver(&test_data).unwrap();
+        assert_eq!(result, "192.168.1.1");
+    }
+
+    #[test]
+    fn test_parse_dns_resolver() {
+        let test_data = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 6, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 12, 0, 0, 0, 12, 108, 97, 110, 0, 0,
+            0, 0, 16, 0, 0, 0, 12, 101, 110, 48, 0, 0, 0, 0, 11, 0, 0, 0, 24, 16, 2, 0, 0, 192,
+            168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 36, 28, 30, 0, 0, 0, 0, 0, 0,
+            253, 169, 223, 235, 210, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 15, 0,
+            0, 0, 20, 68, 101, 102, 97, 117, 108, 116, 58, 32, 48, 0, 0,
+        ];
+
+        let (_, result) = parse_dns_resolver(&test_data).unwrap();
+        assert_eq!(result.nameservers.len(), 2);
+        assert_eq!(result.search_domains[0], "lan");
+        assert_eq!(result.config_id, "Default: 0");
+    }
+
+    #[test]
+    fn test_parse_dns_config() {
+        let test_data = [
+            0, 0, 0, 1, 0, 0, 0, 212, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 6, 0, 2, 0, 2, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 12, 0, 0,
+            0, 12, 108, 97, 110, 0, 0, 0, 0, 16, 0, 0, 0, 12, 101, 110, 48, 0, 0, 0, 0, 11, 0, 0,
+            0, 24, 16, 2, 0, 0, 192, 168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 36,
+            28, 30, 0, 0, 0, 0, 0, 0, 253, 169, 223, 235, 210, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+            0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 20, 68, 101, 102, 97, 117, 108, 116, 58, 32, 48, 0,
+            0, 0, 0, 0, 2, 0, 0, 0, 248, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 16, 6, 0, 2, 0, 2,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 140, 0, 0, 0, 12,
+            0, 0, 0, 12, 108, 97, 110, 0, 0, 0, 0, 16, 0, 0, 0, 12, 101, 110, 48, 0, 0, 0, 0, 11,
+            0, 0, 0, 24, 16, 2, 0, 0, 192, 168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0,
+            36, 28, 30, 0, 0, 0, 0, 0, 0, 253, 169, 223, 235, 210, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 56, 83, 99, 111, 112, 101, 100, 58, 32, 52, 52,
+            70, 56, 67, 67, 50, 68, 45, 67, 65, 66, 51, 45, 52, 57, 69, 65, 45, 66, 50, 67, 48, 45,
+            69, 66, 51, 51, 68, 57, 50, 57, 53, 67, 67, 65, 32, 48, 0, 0, 0, 0, 0, 1, 0, 0, 0, 168,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 5, 0, 4, 147, 224, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 60, 0, 0, 0, 10, 0, 0, 0, 16, 108, 111, 99, 97,
+            108, 0, 0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0, 0, 15, 0,
+            0, 0, 28, 77, 117, 108, 116, 105, 99, 97, 115, 116, 32, 68, 78, 83, 58, 32, 48, 0, 0,
+            0, 0, 0, 0, 0, 1, 0, 0, 0, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 4, 148, 168, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 76, 0, 0, 0,
+            10, 0, 0, 0, 32, 50, 53, 52, 46, 49, 54, 57, 46, 105, 110, 45, 97, 100, 100, 114, 46,
+            97, 114, 112, 97, 0, 0, 0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0, 0, 0,
+            0, 0, 0, 15, 0, 0, 0, 28, 77, 117, 108, 116, 105, 99, 97, 115, 116, 32, 68, 78, 83, 58,
+            32, 49, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 176, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 4, 149, 112, 0, 0, 0, 0, 0, 0, 0,
+            6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68,
+            0, 0, 0, 10, 0, 0, 0, 24, 56, 46, 101, 46, 102, 46, 105, 112, 54, 46, 97, 114, 112, 97,
+            0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0,
+            28, 77, 117, 108, 116, 105, 99, 97, 115, 116, 32, 68, 78, 83, 58, 32, 50, 0, 0, 0, 0,
+            0, 0, 0, 1, 0, 0, 0, 176, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 4, 150, 56, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 0, 0, 0, 10, 0,
+            0, 0, 24, 57, 46, 101, 46, 102, 46, 105, 112, 54, 46, 97, 114, 112, 97, 0, 0, 0, 0, 0,
+            14, 0, 0, 0, 16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 28, 77, 117,
+            108, 116, 105, 99, 97, 115, 116, 32, 68, 78, 83, 58, 32, 51, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+            0, 0, 176, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 5, 0, 4, 151, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 0, 0, 0, 10, 0, 0, 0, 24, 97,
+            46, 101, 46, 102, 46, 105, 112, 54, 46, 97, 114, 112, 97, 0, 0, 0, 0, 0, 14, 0, 0, 0,
+            16, 109, 100, 110, 115, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 28, 77, 117, 108, 116, 105,
+            99, 97, 115, 116, 32, 68, 78, 83, 58, 32, 52, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 176, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            5, 0, 4, 151, 200, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 0, 0, 0, 10, 0, 0, 0, 24, 98, 46, 101, 46, 102,
+            46, 105, 112, 54, 46, 97, 114, 112, 97, 0, 0, 0, 0, 0, 14, 0, 0, 0, 16, 109, 100, 110,
+            115, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 28, 77, 117, 108, 116, 105, 99, 97, 115, 116,
+            32, 68, 78, 83, 58, 32, 53, 0, 0, 0, 0,
+        ];
+
+        let count = 8;
+        let (_, result) = parse_dns_config(&test_data, &count).unwrap();
+        assert!(result.contains("  order    : 300800"))
+    }
+}

--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -352,6 +352,7 @@ pub(crate) fn dns_records(data: &str) -> Result<&'static str, DecoderError<'_>> 
         "2" => "NS",
         "5" => "CNAME",
         "6" => "SOA",
+        "10" => "NULL",
         "12" => "PTR",
         "13" => "HINFO",
         "15" => "MX",

--- a/src/decoders/mod.rs
+++ b/src/decoders/mod.rs
@@ -6,6 +6,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 mod bool;
+pub(crate) mod config;
 mod darwin;
 pub(crate) mod decoder;
 mod dns;

--- a/src/message.rs
+++ b/src/message.rs
@@ -101,7 +101,7 @@ pub fn format_firehose_log_message(
             continue;
         }
 
-        let private_strings = [0x1, 0x21, 0x31, 0x41];
+        let private_strings = [0x1, 0x12, 0x21, 0x31, 0x41];
         let private_number = 0x1;
         let private_message = 0x8000;
         if formatter_string.starts_with("%{") {
@@ -1076,9 +1076,8 @@ fn parse_float(message: String) -> f64 {
     let byte_results = message.parse::<i64>();
     match byte_results {
         Ok(bytes) => return f64::from_bits(bytes as u64),
-        Err(err) => error!(
-            "[macos-unifiedlogs] Failed to parse float log message value: {}, err: {:?}",
-            message, err
+        Err(err) => warn!(
+            "[macos-unifiedlogs] Failed to parse float log message value: {message}, err: {err:?}. Log message possibly incorrectly formatted ex: printf(%u, \"message\") instead of printf(%u, 10). Apple may record message as '<decode: mismatch for [%u] got [STRING sz:10]>'",
         ),
     }
     f64::from_bits(0)
@@ -1089,9 +1088,8 @@ fn parse_int(message: String) -> i64 {
     let int_results = message.parse::<i64>();
     match int_results {
         Ok(message) => return message,
-        Err(err) => error!(
-            "[macos-unifiedlogs] Failed to parse int log message value: {}, err: {:?}",
-            message, err
+        Err(err) => warn!(
+            "[macos-unifiedlogs] Failed to parse int log message value: {message}, err: {err:?}. Log message possibly incorrectly formatted ex: printf(%u, \"message\") instead of printf(%u, 10). Apple may record message as '<decode: mismatch for [%u] got [STRING sz:10]>'",
         ),
     }
     0
@@ -1119,6 +1117,60 @@ mod tests {
 
         let log_string = format_firehose_log_message(test_data, &item_message, &message_re);
         assert_eq!(log_string, "opendirectoryd (build 796.100) launched...")
+    }
+
+    #[test]
+    fn test_bad_format_options() {
+        let message_re = Regex::new(r"(%(?:(?:\{[^}]+}?)(?:[-+0#]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*))?(?:h|hh|l|ll|w|I|z|t|q|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%}]|(?:[-+0 #]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*))?(?:h|hh|l||q|t|ll|w|I|z|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%]))").unwrap();
+        let message = String::from(
+            "PAVAbstractVideoInterface.cpp::%d] DCPAV[%d] %s::%s Setting %s syncWidth = %u",
+        );
+
+        let items = vec![
+            FirehoseItemInfo {
+                message_strings: String::from("406"),
+                item_type: 0,
+                item_size: 0,
+            },
+            FirehoseItemInfo {
+                message_strings: String::from("258"),
+                item_type: 0,
+                item_size: 0,
+            },
+            FirehoseItemInfo {
+                message_strings: String::from("DCPAVSimpleVideoInterface"),
+                item_type: 32,
+                item_size: 25,
+            },
+            FirehoseItemInfo {
+                message_strings: String::from("setColorElement"),
+                item_type: 32,
+                item_size: 15,
+            },
+            FirehoseItemInfo {
+                message_strings: String::from("3"),
+                item_type: 0,
+                item_size: 0,
+            },
+            FirehoseItemInfo {
+                message_strings: String::from("All"),
+                item_type: 32,
+                item_size: 3,
+            },
+            FirehoseItemInfo {
+                message_strings: String::from("89"),
+                item_type: 0,
+                item_size: 0,
+            },
+        ];
+
+        let log_string = format_firehose_log_message(message, &items, &message_re);
+        // The printf format options are bad/wrong for this message. We log warning and return 0 default
+        // Apple records as: <decode: mismatch for [%u] got [STRING sz:3]
+        assert_eq!(
+            log_string,
+            "PAVAbstractVideoInterface.cpp::406] DCPAV[258] DCPAVSimpleVideoInterface::setColorElement Setting 3 syncWidth = 0"
+        )
     }
 
     #[test]

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -210,7 +210,7 @@ impl Iterator for LogIterator<'_> {
                     timezone_name: self.unified_log_data.header[0]
                         .timezone_path
                         .split('/')
-                        .last()
+                        .next_back()
                         .unwrap_or("Unknown Timezone Name")
                         .to_string(),
                     library_uuid: String::new(),
@@ -562,7 +562,7 @@ impl Iterator for LogIterator<'_> {
                 timezone_name: self.unified_log_data.header[0]
                     .timezone_path
                     .split('/')
-                    .last()
+                    .next_back()
                     .unwrap_or("Unknown Timezone Name")
                     .to_string(),
                 library_uuid: simpledump.sender_uuid.to_owned(),
@@ -638,7 +638,7 @@ impl Iterator for LogIterator<'_> {
                 timezone_name: self.unified_log_data.header[0]
                     .timezone_path
                     .split('/')
-                    .last()
+                    .next_back()
                     .unwrap_or("Unknown Timezone Name")
                     .to_string(),
                 library_uuid: String::new(),

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -266,7 +266,7 @@ fn test_parse_all_logs_big_sur() {
     assert_eq!(unknown_strings, 0);
     assert_eq!(invalid_offsets, 54);
     assert_eq!(invalid_shared_string_offsets, 0);
-    assert_eq!(statedump_custom_objects, 1);
+    assert_eq!(statedump_custom_objects, 0);
     assert_eq!(statedump_protocol_buffer, 0);
     assert_eq!(found_precision_string, true);
 

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -266,7 +266,7 @@ fn test_parse_all_logs_big_sur() {
     assert_eq!(unknown_strings, 0);
     assert_eq!(invalid_offsets, 54);
     assert_eq!(invalid_shared_string_offsets, 0);
-    assert_eq!(statedump_custom_objects, 2);
+    assert_eq!(statedump_custom_objects, 1);
     assert_eq!(statedump_protocol_buffer, 0);
     assert_eq!(found_precision_string, true);
 

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -277,6 +277,6 @@ fn test_parse_all_logs_high_sierra() {
     assert_eq!(unknown_strings, 0);
     assert_eq!(invalid_offsets, 3);
     assert_eq!(invalid_shared_string_offsets, 0);
-    assert_eq!(statedump_custom_objects, 1);
+    assert_eq!(statedump_custom_objects, 0);
     assert_eq!(statedump_protocol_buffer, 0);
 }

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -277,6 +277,6 @@ fn test_parse_all_logs_high_sierra() {
     assert_eq!(unknown_strings, 0);
     assert_eq!(invalid_offsets, 3);
     assert_eq!(invalid_shared_string_offsets, 0);
-    assert_eq!(statedump_custom_objects, 2);
+    assert_eq!(statedump_custom_objects, 1);
     assert_eq!(statedump_protocol_buffer, 0);
 }

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -173,7 +173,7 @@ fn test_parse_all_logs_monterey() {
     assert_eq!(unknown_strings, 531);
     assert_eq!(invalid_offsets, 60);
     assert_eq!(invalid_shared_string_offsets, 309);
-    assert_eq!(statedump_custom_objects, 2);
+    assert_eq!(statedump_custom_objects, 1);
     assert_eq!(statedump_protocol_buffer, 0);
     assert_eq!(string_count, 28196); // Accurate count based on log raw-dump -a <monterey.logarchive> | grep "format:\s*%s$" | sort | uniq -c | sort -n
     assert_eq!(mutilities_worldclock, 57);

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -173,7 +173,7 @@ fn test_parse_all_logs_monterey() {
     assert_eq!(unknown_strings, 531);
     assert_eq!(invalid_offsets, 60);
     assert_eq!(invalid_shared_string_offsets, 309);
-    assert_eq!(statedump_custom_objects, 1);
+    assert_eq!(statedump_custom_objects, 0);
     assert_eq!(statedump_protocol_buffer, 0);
     assert_eq!(string_count, 28196); // Accurate count based on log raw-dump -a <monterey.logarchive> | grep "format:\s*%s$" | sort | uniq -c | sort -n
     assert_eq!(mutilities_worldclock, 57);


### PR DESCRIPTION
This PR adds support for parsing the DNS and Network Interface (NWI) objects in log messages.
In addition, this PR adds another private string flag id when formatting messages.
