### PR TITLE
Fix clippy warnings

### DIFF
--- a/benches/big_sur_benchmark.rs
+++ b/benches/big_sur_benchmark.rs
@@ -26,7 +26,7 @@ fn bench_build_log(
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) {
-    let (_, _) = build_log(&log_data, provider, &timesync_data, exclude_missing);
+    let (_, _) = build_log(log_data, provider, timesync_data, exclude_missing);
 }
 
 fn big_sur_single_log_benchpress(c: &mut Criterion) {

--- a/benches/high_sierra_benchmark.rs
+++ b/benches/high_sierra_benchmark.rs
@@ -26,7 +26,7 @@ fn bench_build_log(
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) {
-    let (_, _) = build_log(&log_data, provider, &timesync_data, exclude_missing);
+    let (_, _) = build_log(log_data, provider, timesync_data, exclude_missing);
 }
 
 fn high_sierra_single_log_benchpress(c: &mut Criterion) {

--- a/benches/monterey_benchmark.rs
+++ b/benches/monterey_benchmark.rs
@@ -25,7 +25,7 @@ fn bench_build_log(
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) {
-    let (_, _) = build_log(&log_data, provider, &timesync_data, exclude_missing);
+    let (_, _) = build_log(log_data, provider, timesync_data, exclude_missing);
 }
 
 fn monterey_single_log_benchpress(c: &mut Criterion) {

--- a/examples/unifiedlog_iterator/src/main.rs
+++ b/examples/unifiedlog_iterator/src/main.rs
@@ -302,7 +302,7 @@ pub struct OutputWriter {
 }
 
 enum OutputWriterEnum {
-    Csv(Writer<Box<dyn Write>>),
+    Csv(Box<Writer<Box<dyn Write>>>),
     Json(Box<dyn Write>),
 }
 
@@ -332,7 +332,7 @@ impl OutputWriter {
                     "System Timezone Name",
                 ])?;
                 csv_writer.flush()?;
-                OutputWriterEnum::Csv(csv_writer)
+                OutputWriterEnum::Csv(Box::new(csv_writer))
             }
             "jsonl" => OutputWriterEnum::Json(writer),
             _ => {

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -643,10 +643,7 @@ mod tests {
             68, 234, 2, 0, 119, 171, 170, 119, 76, 234, 2, 0, 240, 254, 0, 0, 0, 1, 0, 0, 1, 0, 0,
             0, 0, 0, 3, 0, 0, 0, 0, 0, 19, 0, 47, 0,
         ];
-        assert!(matches!(
-            CatalogChunk::parse_catalog_subchunk(test_bad_compression),
-            Err(_)
-        ));
+        assert!(CatalogChunk::parse_catalog_subchunk(test_bad_compression).is_err());
     }
 
     #[test]

--- a/src/chunks/statedump.rs
+++ b/src/chunks/statedump.rs
@@ -104,7 +104,7 @@ impl Statedump {
         statedump_results.unknown_data_type = statedump_unknown_data_type;
         statedump_results.unknown_data_size = statedump_unknown_data_size;
 
-        let uuid_string = format!("{:02X?}", uuid);
+        let uuid_string = format!("{uuid:02X?}");
         statedump_results.uuid = clean_uuid(&uuid_string);
 
         let (input, statedump_data) = take(statedump_unknown_data_size)(input)?;

--- a/src/decoders/config.rs
+++ b/src/decoders/config.rs
@@ -363,7 +363,7 @@ fn parse_interface<'a>(
             ip,
             rank,
             reach,
-            signature: format!("0x{:02x?}", sig)
+            signature: format!("0x{sig:02x?}")
                 .replace(", ", "")
                 .replace("[", "")
                 .replace("]", ""),

--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -156,7 +156,7 @@ pub(crate) fn get_domain_name(input: &str) -> Result<String, DecoderError<'_>> {
     let non_domain_chars = ['\n', '\t', '\r'];
     for unicode in results.chars() {
         // skip non-domain characters and replace with '.'
-        if non_domain_chars.contains(&unicode) || format!("{:?}", unicode).contains("\\u{") {
+        if non_domain_chars.contains(&unicode) || format!("{unicode:?}").contains("\\u{") {
             clean_domain.push('.');
             continue;
         }
@@ -286,7 +286,7 @@ fn parse_mac_addr(input: &[u8]) -> nom::IResult<&[u8], String> {
             if !acc.is_empty() {
                 acc.push(':');
             }
-            write!(&mut acc, "{:02X?}", item).ok(); // ignore errors on write in String
+            write!(&mut acc, "{item:02X?}").ok(); // ignore errors on write in String
             acc
         },
     )

--- a/src/decoders/location.rs
+++ b/src/decoders/location.rs
@@ -174,9 +174,7 @@ fn get_sqlite_data(input: &[u8]) -> IResult<&[u8], &'static str> {
         101 => "SQLITE DONE",
         266 => "SQLITE IO ERR READ",
         _ => {
-            warn!(
-                "[macos-unifiedlogs] Unknown Core Location sqlite error: {sqlite_code}"
-            );
+            warn!("[macos-unifiedlogs] Unknown Core Location sqlite error: {sqlite_code}");
             "Unknown Core Location sqlite error"
         }
     };

--- a/src/decoders/location.rs
+++ b/src/decoders/location.rs
@@ -175,8 +175,7 @@ fn get_sqlite_data(input: &[u8]) -> IResult<&[u8], &'static str> {
         266 => "SQLITE IO ERR READ",
         _ => {
             warn!(
-                "[macos-unifiedlogs] Unknown Core Location sqlite error: {}",
-                sqlite_code
+                "[macos-unifiedlogs] Unknown Core Location sqlite error: {sqlite_code}"
             );
             "Unknown Core Location sqlite error"
         }
@@ -210,7 +209,7 @@ pub(crate) fn get_state_tracker_data(input: &[u8]) -> IResult<&[u8], String> {
         input,
         format!(
             "{{\"locationRestricted\":{}, \"locationServicesenabledStatus\":{}}}",
-            lowercase_bool(&format!("{}", location_restricted)),
+            lowercase_bool(&format!("{location_restricted}")),
             location_enabled
         ),
     ))

--- a/src/decoders/uuid.rs
+++ b/src/decoders/uuid.rs
@@ -16,7 +16,7 @@ pub(crate) fn parse_uuid(input: &str) -> Result<String, DecoderError<'_>> {
         message: "Failed to base64 decode uuid data",
     })?;
 
-    let mut uuid_string = format!("{:02X?}", decoded_data);
+    let mut uuid_string = format!("{decoded_data:02X?}");
     uuid_string = clean_uuid(&uuid_string);
     Ok(uuid_string)
 }

--- a/src/dsc.rs
+++ b/src/dsc.rs
@@ -179,7 +179,7 @@ impl SharedCacheStrings {
         let (_, dsc_path_offset) = le_u32(path_offset)?;
 
         uuid_data.text_size = dsc_text_size;
-        uuid_data.uuid = format!("{:X}", dsc_uuid);
+        uuid_data.uuid = format!("{dsc_uuid:X}");
         uuid_data.path_offset = dsc_path_offset;
 
         Ok((input, uuid_data))

--- a/src/header.rs
+++ b/src/header.rs
@@ -162,7 +162,7 @@ impl HeaderChunk {
         }
 
         let (_, boot_uuid_be) = be_u128(boot_uuid)?;
-        header_chunk.boot_uuid = format!("{:X}", boot_uuid_be);
+        header_chunk.boot_uuid = format!("{boot_uuid_be:X}");
 
         Ok((input, header_chunk))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
     clippy::all,
     clippy::doc_markdown,
     clippy::needless_continue,
-    clippy::match_on_vec_items,
     clippy::imprecise_flops,
     clippy::suboptimal_flops,
     clippy::lossy_float_literal,

--- a/src/message.rs
+++ b/src/message.rs
@@ -892,54 +892,40 @@ fn format_left(
         }
 
         message = format!(
-            "{plus_symbol}{float_message:<.precision$}",
-            precision = precision_value,
-            plus_symbol = plus_option
+            "{plus_option}{float_message:<.precision_value$}"
         );
     } else if INT_TYPES.contains(&type_data) {
         let int_message = parse_int(message);
         message = format!(
-            "{plus_symbol}{int_message:<.precision$}",
-            precision = precision_value,
-            plus_symbol = plus_option
+            "{plus_option}{int_message:<.precision_value$}"
         );
     } else if STRING_TYPES.contains(&type_data) {
         if precision_value == 0 {
             precision_value = message.len()
         }
         message = format!(
-            "{plus_symbol}{message:<.precision$}",
-            precision = precision_value,
-            plus_symbol = plus_option
+            "{plus_option}{message:<.precision_value$}"
         );
     } else if HEX_TYPES.contains(&type_data) {
         let hex_message = parse_int(message);
         if hashtag {
             message = format!(
-                "{plus_symbol}{hex_message:<#.precision$X}",
-                precision = precision_value,
-                plus_symbol = plus_option
+                "{plus_option}{hex_message:<#.precision_value$X}"
             );
         } else {
             message = format!(
-                "{plus_symbol}{hex_message:<.precision$X}",
-                precision = precision_value,
-                plus_symbol = plus_option
+                "{plus_option}{hex_message:<.precision_value$X}"
             );
         }
     } else if OCTAL_TYPES.contains(&type_data) {
         let octal_message = parse_int(message);
         if hashtag {
             message = format!(
-                "{plus_symbol}{octal_message:<#.precision$o}",
-                precision = precision_value,
-                plus_symbol = plus_option
+                "{plus_option}{octal_message:<#.precision_value$o}"
             );
         } else {
             message = format!(
-                "{plus_symbol}{octal_message:<.precision$o}",
-                precision = precision_value,
-                plus_symbol = plus_option
+                "{plus_option}{octal_message:<.precision_value$o}"
             );
         }
     }
@@ -973,47 +959,35 @@ fn format_right(
         }
 
         message = format!(
-            "{plus_symbol}{float_message:>.precision$}",
-            precision = precision_value,
-            plus_symbol = plus_option
+            "{plus_option}{float_message:>.precision_value$}"
         );
     } else if INT_TYPES.contains(&type_data) {
         let int_message = parse_int(message);
         message = format!(
-            "{plus_symbol}{int_message:>.precision$}",
-            precision = precision_value,
-            plus_symbol = plus_option
+            "{plus_option}{int_message:>.precision_value$}"
         );
     } else if STRING_TYPES.contains(&type_data) {
         if precision_value == 0 {
             precision_value = message.len()
         }
         message = format!(
-            "{plus_symbol}{message:>.precision$}",
-            precision = precision_value,
-            plus_symbol = plus_option
+            "{plus_option}{message:>.precision_value$}"
         );
     } else if HEX_TYPES.contains(&type_data) {
         let hex_message = parse_int(message);
         if hashtag {
             message = format!(
-                "{plus_symbol}{hex_message:>#.precision$X}",
-                precision = precision_value,
-                plus_symbol = plus_option
+                "{plus_option}{hex_message:>#.precision_value$X}"
             );
         } else {
             message = format!(
-                "{plus_symbol}{hex_message:>.precision$X}",
-                precision = precision_value,
-                plus_symbol = plus_option
+                "{plus_option}{hex_message:>.precision_value$X}"
             );
         }
     } else if OCTAL_TYPES.contains(&type_data) {
         let octal_message = parse_int(message);
         message = format!(
-            "{plus_symbol}{octal_message:>#.precision$o}",
-            precision = precision_value,
-            plus_symbol = plus_option
+            "{plus_option}{octal_message:>#.precision_value$o}"
         );
     }
     message

--- a/src/message.rs
+++ b/src/message.rs
@@ -891,42 +891,28 @@ fn format_left(
             }
         }
 
-        message = format!(
-            "{plus_option}{float_message:<.precision_value$}"
-        );
+        message = format!("{plus_option}{float_message:<.precision_value$}");
     } else if INT_TYPES.contains(&type_data) {
         let int_message = parse_int(message);
-        message = format!(
-            "{plus_option}{int_message:<.precision_value$}"
-        );
+        message = format!("{plus_option}{int_message:<.precision_value$}");
     } else if STRING_TYPES.contains(&type_data) {
         if precision_value == 0 {
             precision_value = message.len()
         }
-        message = format!(
-            "{plus_option}{message:<.precision_value$}"
-        );
+        message = format!("{plus_option}{message:<.precision_value$}");
     } else if HEX_TYPES.contains(&type_data) {
         let hex_message = parse_int(message);
         if hashtag {
-            message = format!(
-                "{plus_option}{hex_message:<#.precision_value$X}"
-            );
+            message = format!("{plus_option}{hex_message:<#.precision_value$X}");
         } else {
-            message = format!(
-                "{plus_option}{hex_message:<.precision_value$X}"
-            );
+            message = format!("{plus_option}{hex_message:<.precision_value$X}");
         }
     } else if OCTAL_TYPES.contains(&type_data) {
         let octal_message = parse_int(message);
         if hashtag {
-            message = format!(
-                "{plus_option}{octal_message:<#.precision_value$o}"
-            );
+            message = format!("{plus_option}{octal_message:<#.precision_value$o}");
         } else {
-            message = format!(
-                "{plus_option}{octal_message:<.precision_value$o}"
-            );
+            message = format!("{plus_option}{octal_message:<.precision_value$o}");
         }
     }
     message
@@ -958,37 +944,25 @@ fn format_right(
             }
         }
 
-        message = format!(
-            "{plus_option}{float_message:>.precision_value$}"
-        );
+        message = format!("{plus_option}{float_message:>.precision_value$}");
     } else if INT_TYPES.contains(&type_data) {
         let int_message = parse_int(message);
-        message = format!(
-            "{plus_option}{int_message:>.precision_value$}"
-        );
+        message = format!("{plus_option}{int_message:>.precision_value$}");
     } else if STRING_TYPES.contains(&type_data) {
         if precision_value == 0 {
             precision_value = message.len()
         }
-        message = format!(
-            "{plus_option}{message:>.precision_value$}"
-        );
+        message = format!("{plus_option}{message:>.precision_value$}");
     } else if HEX_TYPES.contains(&type_data) {
         let hex_message = parse_int(message);
         if hashtag {
-            message = format!(
-                "{plus_option}{hex_message:>#.precision_value$X}"
-            );
+            message = format!("{plus_option}{hex_message:>#.precision_value$X}");
         } else {
-            message = format!(
-                "{plus_option}{hex_message:>.precision_value$X}"
-            );
+            message = format!("{plus_option}{hex_message:>.precision_value$X}");
         }
     } else if OCTAL_TYPES.contains(&type_data) {
         let octal_message = parse_int(message);
-        message = format!(
-            "{plus_option}{octal_message:>#.precision_value$o}"
-        );
+        message = format!("{plus_option}{octal_message:>#.precision_value$o}");
     }
     message
 }

--- a/src/timesync.rs
+++ b/src/timesync.rs
@@ -111,7 +111,7 @@ impl TimesyncBoot {
             signature: timesync_signature,
             header_size: timesync_header_size,
             unknown: timesync_unknown,
-            boot_uuid: format!("{:X}", timesync_boot_uuid),
+            boot_uuid: format!("{timesync_boot_uuid:X}"),
             timebase_numerator: timesync_timebase_numerator,
             timebase_denominator: timesync_timebase_denominator,
             boot_time: timesync_boot_time,
@@ -237,8 +237,6 @@ mod tests {
     use crate::filesystem::LogarchiveProvider;
     use crate::parser::collect_timesync;
     use crate::timesync::TimesyncBoot;
-    use std::fs::File;
-    use std::io::Read;
     use std::path::PathBuf;
 
     #[test]
@@ -248,9 +246,7 @@ mod tests {
             "tests/test_data/system_logs_big_sur.logarchive/timesync/0000000000000002.timesync",
         );
 
-        let mut open = File::open(test_path).unwrap();
-        let mut buffer = Vec::new();
-        open.read_to_end(&mut buffer).unwrap();
+        let buffer = std::fs::read(test_path).unwrap();
 
         let (_, timesync_data) = TimesyncBoot::parse_timesync_data(&buffer).unwrap();
         assert_eq!(timesync_data.len(), 5);
@@ -271,9 +267,7 @@ mod tests {
         test_path
             .push("tests/test_data/Bad Data/Timesync/Bad_Boot_header_0000000000000002.timesync");
 
-        let mut open = File::open(test_path).unwrap();
-        let mut buffer = Vec::new();
-        open.read_to_end(&mut buffer).unwrap();
+        let buffer = std::fs::read(test_path).unwrap();
 
         let (_, _) = TimesyncBoot::parse_timesync_data(&buffer).unwrap();
     }
@@ -285,9 +279,7 @@ mod tests {
         test_path
             .push("tests/test_data/Bad Data/Timesync/Bad_Record_header_0000000000000002.timesync");
 
-        let mut open = File::open(test_path).unwrap();
-        let mut buffer = Vec::new();
-        open.read_to_end(&mut buffer).unwrap();
+        let buffer = std::fs::read(test_path).unwrap();
 
         let (_, _) = TimesyncBoot::parse_timesync_data(&buffer).unwrap();
     }
@@ -298,9 +290,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/Bad Data/Timesync/Bad_content_0000000000000002.timesync");
 
-        let mut open = File::open(test_path).unwrap();
-        let mut buffer = Vec::new();
-        open.read_to_end(&mut buffer).unwrap();
+        let buffer = std::fs::read(test_path).unwrap();
 
         let (_, _) = TimesyncBoot::parse_timesync_data(&buffer).unwrap();
     }
@@ -311,9 +301,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/Bad Data/Timesync/BadFile.timesync");
 
-        let mut open = File::open(test_path).unwrap();
-        let mut buffer = Vec::new();
-        open.read_to_end(&mut buffer).unwrap();
+        let buffer = std::fs::read(test_path).unwrap();
 
         let (_, _) = TimesyncBoot::parse_timesync_data(&buffer).unwrap();
     }

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -168,7 +168,7 @@ fn test_parse_all_logs_big_sur() {
     let mut log_data_vec: Vec<LogData> = Vec::new();
     let exclude_missing = false;
     for logs in &log_data {
-        let (mut data, _) = build_log(&logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     // Run: "log raw-dump -a macos-unifiedlogs/tests/test_data/system_logs_big_sur.logarchive"
@@ -273,7 +273,7 @@ fn test_parse_all_logs_big_sur() {
     assert_eq!(invalid_shared_string_offsets, 0);
     assert_eq!(statedump_custom_objects, 0);
     assert_eq!(statedump_protocol_buffer, 0);
-    assert_eq!(found_precision_string, true);
+    assert!(found_precision_string);
 
     assert_eq!(statedump_count, 322);
     assert_eq!(signpost_count, 50665);
@@ -305,7 +305,7 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
     let exclude_missing = false;
 
     for logs in &log_data {
-        let (mut data, _) = build_log(&logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
 
@@ -374,7 +374,7 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
     assert_eq!(messages_containing_network, 9173);
     // Console.app is missing a log entry. The log command shows the entry
     assert_eq!(default_type, 8320);
-    assert_eq!(network_message_uuid, true);
+    assert!(network_message_uuid);
 
     assert_eq!(info_type, 638);
     assert_eq!(error_type, 215);
@@ -396,7 +396,7 @@ fn test_parse_all_logs_private_big_sur() {
     let mut log_data_vec: Vec<LogData> = Vec::new();
     let exclude_missing = false;
     for logs in &log_data {
-        let (mut data, _) = build_log(&logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 887890);
@@ -405,7 +405,7 @@ fn test_parse_all_logs_private_big_sur() {
     let mut not_found = 0;
     let mut staff_count = 0;
     for logs in log_data_vec {
-        if logs.message == "" {
+        if logs.message.is_empty() {
             empty_counter += 1;
         }
         if logs.message.contains("<not found>") {
@@ -435,7 +435,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur() {
     let exclude_missing = false;
 
     for logs in &log_data {
-        let (mut data, _) = build_log(&logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 1287628);
@@ -523,7 +523,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_single_file() {
 
     assert_eq!(hex_count, 4);
     assert_eq!(dns, 801);
-    assert_eq!(public_private_mixture, true);
+    assert!(public_private_mixture);
 }
 
 // We are able to get 2238 entries from this special tracev3 file. But log command only gets 231
@@ -596,7 +596,7 @@ fn test_big_sur_missing_oversize_strings() {
     let mut missing_strings = 0;
     for results in data {
         if results.message.contains("<Missing message data>") {
-            missing_strings = missing_strings + 1;
+            missing_strings += 1;
         }
     }
     // There should be only 29 entries that have actual missing data
@@ -643,7 +643,7 @@ fn test_big_sur_oversize_strings_in_another_file() {
     let mut missing_strings = 0;
     for results in data {
         if results.message.contains("<Missing message data>") {
-            missing_strings = missing_strings + 1;
+            missing_strings += 1;
         }
     }
     // 29 log entries actually have missing data

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -185,7 +185,7 @@ fn test_parse_all_logs_high_sierra() {
 
     let exclude_missing = false;
     for logs in &log_data {
-        let (mut data, _) = build_log(&logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 569796);
@@ -202,7 +202,7 @@ fn test_parse_all_logs_high_sierra() {
     let message_re = Regex::new(r"^[\s]*%s\s*$").unwrap();
 
     for logs in &log_data_vec {
-        if logs.message == "" {
+        if logs.message.is_empty() {
             empty_counter += 1;
 
             if logs.process

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -101,7 +101,7 @@ fn test_parse_all_logs_monterey() {
     let message_re = Regex::new(r"^[\s]*%s\s*$").unwrap();
 
     for logs in &log_data {
-        let (mut data, _) = build_log(&logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 2397109);


### PR DESCRIPTION
As of Rust 1.88, there are many clippy warnings throughout the project. I've cleaned them up. Note that there is also a clippy lint that has been removed as of 1.88, which I have removed.