### PR TITLE
Add message flags to output

### DIFF
--- a/.changes/unreleased/Added-20260421-230223.yaml
+++ b/.changes/unreleased/Added-20260421-230223.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Exposed message flags to final output
+time: 2026-04-21T23:02:23.399844-04:00

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -6,6 +6,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use crate::catalog::CatalogChunk;
+use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
 use crate::traits::FileProvider;
@@ -24,6 +25,7 @@ pub struct FirehoseActivity {
     pub message_string_ref: u32,
     pub pc_id: u32, // Appears to be used to calculate string offset for firehose events with Absolute flag
     pub firehose_formatters: FirehoseFormatters,
+    pub flags: Vec<MessageFlags>,
 }
 
 impl FirehoseActivity {
@@ -54,6 +56,7 @@ impl FirehoseActivity {
             debug!("[macos-unifiedlogs] Activity Firehose log chunk has unique_pid flag");
             let (firehose_input, firehose_unique_pid) = le_u64(input)?;
             activity.pid = firehose_unique_pid;
+            activity.flags.push(MessageFlags::HasUniquePid);
             input = firehose_input;
         }
 
@@ -65,6 +68,8 @@ impl FirehoseActivity {
 
             activity.activity_id_2 = firehose_activity_id;
             activity.sentinal_2 = firehose_sentinel;
+            activity.flags.push(MessageFlags::HasCurrentAid);
+
             input = firehose_input;
         }
 
@@ -78,14 +83,19 @@ impl FirehoseActivity {
 
             activity.activity_id_3 = firehose_activity_id;
             activity.sentinal_3 = firehose_sentinel;
+            activity.flags.push(MessageFlags::HasOtherAid);
+
             input = firehose_input;
         }
         let (input, firehose_pc_id) = le_u32(input)?;
         activity.pc_id = firehose_pc_id; // Message string reference?
 
         // Check for flags related to base string format location (shared string file (dsc) or UUID file)
-        let (input, formatters) =
-            FirehoseFormatters::firehose_formatter_flags(input, firehose_flags)?;
+        let (input, formatters) = FirehoseFormatters::firehose_formatter_flags(
+            input,
+            firehose_flags,
+            &mut activity.flags,
+        )?;
         activity.firehose_formatters = formatters;
         Ok((input, activity))
     }

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -66,6 +66,7 @@ pub struct Firehose {
     pub firehose_trace: FirehoseTrace,
     pub item: u8,
     pub number_items: u8,
+    pub message_flags: Vec<MessageFlags>,
     /// Log values extracted
     pub message: FirehoseItemData,
 }
@@ -95,6 +96,28 @@ pub enum FirehoseItem {
     Object,
     #[default]
     Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum MessageFlags {
+    SharedCache,
+    MainExe,
+    HasLargeOffset,
+    LargeSharedCache,
+    Absolute,
+    UuidRelative,
+    MainPlugin,
+    PcStyle,
+    HasUniquePid,
+    HasCurrentAid,
+    HasOtherAid,
+    HasRules,
+    HasName,
+    AltIndex,
+    Unknown,
+    HasPrivateData,
+    HasOversize,
+    HasSubsystem,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/chunks/firehose/flags.rs
+++ b/src/chunks/firehose/flags.rs
@@ -9,6 +9,8 @@ use log::{debug, error};
 use nom::Needed;
 use nom::number::complete::{be_u128, le_u16};
 
+use crate::chunks::firehose::firehose_log::MessageFlags;
+
 #[derive(Debug, Clone, Default)]
 pub struct FirehoseFormatters {
     pub main_exe: bool,
@@ -19,15 +21,16 @@ pub struct FirehoseFormatters {
     pub uuid_relative: String,
     pub main_plugin: bool,       // Not seen yet
     pub pc_style: bool,          // Not seen yet
-    pub main_exe_alt_index: u16, // If log entry uses an alternative uuid file index (ex: absolute). This value gets prepended to the unknown_pc_id/offset
+    pub main_exe_alt_index: u16, // If log entry uses an alternative uuid file index (ex: absolute). This value gets prepended to the pc_id/offset
 }
 
 impl FirehoseFormatters {
     /// Identify formatter flags associated with the log entry. Formatter flags determine the file where the base format string is located
-    pub fn firehose_formatter_flags(
-        data: &[u8],
+    pub fn firehose_formatter_flags<'a>(
+        data: &'a [u8],
         firehose_flags: u16,
-    ) -> nom::IResult<&[u8], FirehoseFormatters> {
+        flags: &mut Vec<MessageFlags>,
+    ) -> nom::IResult<&'a [u8], FirehoseFormatters> {
         let mut formatter_flags = FirehoseFormatters::default();
 
         let message_strings_uuid = 0x2; // main_exe flag
@@ -52,15 +55,18 @@ impl FirehoseFormatters {
                 let (firehose_input, firehose_large_offset) = le_u16(input)?;
                 formatter_flags.has_large_offset = firehose_large_offset;
                 input = firehose_input;
+                flags.push(MessageFlags::HasLargeOffset);
                 if (firehose_flags & large_shared_cache) != 0 {
                     debug!(
                         "[macos-unifiedlogs] Firehose flag: large_shared_cache and has_large_offset"
                     );
                     let (firehose_input, firehose_large_shared_cache) = le_u16(firehose_input)?;
                     formatter_flags.large_shared_cache = firehose_large_shared_cache;
+                    flags.push(MessageFlags::LargeSharedCache);
                     input = firehose_input;
                 } else if (firehose_flags & shared_cache) != 0 {
                     formatter_flags.shared_cache = true;
+                    flags.push(MessageFlags::SharedCache);
                 }
             }
             0xc => {
@@ -69,32 +75,39 @@ impl FirehoseFormatters {
                     let (firehose_input, firehose_large_offset) = le_u16(input)?;
                     formatter_flags.has_large_offset = firehose_large_offset;
                     input = firehose_input;
+                    flags.push(MessageFlags::HasLargeOffset);
                 }
                 let (firehose_input, firehose_large_shared_cache) = le_u16(input)?;
                 formatter_flags.large_shared_cache = firehose_large_shared_cache;
+                flags.push(MessageFlags::LargeSharedCache);
                 input = firehose_input;
             }
             0x8 => {
                 debug!("[macos-unifiedlogs] Firehose flag: absolute");
                 formatter_flags.absolute = true;
+                flags.push(MessageFlags::Absolute);
                 if (firehose_flags & message_strings_uuid) == 0 {
                     debug!("[macos-unifiedlogs] Firehose flag: alt index absolute flag");
                     let (firehose_input, firehose_uuid_file_index) = le_u16(input)?;
                     formatter_flags.main_exe_alt_index = firehose_uuid_file_index;
                     input = firehose_input;
+                    flags.push(MessageFlags::AltIndex);
                 }
             }
             0x2 => {
                 debug!("[macos-unifiedlogs] Firehose flag: main_exe");
-                formatter_flags.main_exe = true
+                formatter_flags.main_exe = true;
+                flags.push(MessageFlags::MainExe);
             }
             0x4 => {
                 debug!("[macos-unifiedlogs] Firehose flag: shared_cache");
                 formatter_flags.shared_cache = true;
+                flags.push(MessageFlags::SharedCache);
                 if (firehose_flags & large_offset) != 0 {
                     let (firehose_input, firehose_large_offset) = le_u16(input)?;
                     formatter_flags.has_large_offset = firehose_large_offset;
                     input = firehose_input;
+                    flags.push(MessageFlags::HasLargeOffset);
                 }
             }
             0xa => {
@@ -102,10 +115,12 @@ impl FirehoseFormatters {
                 let (firehose_input, firehose_uuid_relative) = be_u128(input)?;
                 formatter_flags.uuid_relative = format!("{firehose_uuid_relative:032X}");
                 input = firehose_input;
+                flags.push(MessageFlags::UuidRelative);
             }
             _ => {
                 error!("[macos-unifiedlogs] Unknown Firehose formatter flag: {firehose_flags:?}");
                 debug!("[macos-unifiedlogs] Firehose data: {data:X?}");
+                flags.push(MessageFlags::Unknown);
                 return Err(nom::Err::Incomplete(Needed::Unknown));
             }
         }
@@ -115,7 +130,7 @@ impl FirehoseFormatters {
 
 #[cfg(test)]
 mod tests {
-    use crate::chunks::firehose::flags::FirehoseFormatters;
+    use crate::chunks::firehose::{firehose_log::MessageFlags, flags::FirehoseFormatters};
 
     #[test]
     fn test_firehose_formatter_flags_has_large_offset() {
@@ -123,28 +138,41 @@ mod tests {
             1, 0, 2, 0, 14, 0, 34, 2, 0, 4, 135, 16, 0, 0, 34, 4, 0, 0, 5, 0, 100, 101, 110, 121, 0,
         ];
         let test_flags = 557;
+        let mut flags = Vec::new();
         let (_, results) =
-            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags).unwrap();
+            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags, &mut flags)
+                .unwrap();
         assert_eq!(results.has_large_offset, 1);
         assert_eq!(results.large_shared_cache, 2);
+        assert_eq!(
+            flags,
+            vec![MessageFlags::HasLargeOffset, MessageFlags::LargeSharedCache]
+        );
     }
 
     #[test]
     fn test_firehose_formatter_flags_message_strings_uuid_message_alt_index() {
         let test_data = [8, 0, 17, 166, 251, 2, 128, 255, 0, 0];
         let test_flags = 8;
+        let mut flags = Vec::new();
+
         let (_, results) =
-            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags).unwrap();
-        assert_eq!(results.main_exe_alt_index, 8)
+            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags, &mut flags)
+                .unwrap();
+        assert_eq!(results.main_exe_alt_index, 8);
+        assert_eq!(flags, vec![MessageFlags::Absolute, MessageFlags::AltIndex]);
     }
 
     #[test]
     fn test_firehose_formatter_flags_message_strings_uuid() {
         let test_data = [186, 0, 0, 0];
         let test_flags = 514;
+        let mut flags = Vec::new();
         let (_, results) =
-            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags).unwrap();
+            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags, &mut flags)
+                .unwrap();
         assert!(results.main_exe);
+        assert_eq!(flags, vec![MessageFlags::MainExe]);
     }
 
     #[test]
@@ -155,9 +183,13 @@ mod tests {
             110, 116, 101, 114, 0,
         ];
         let test_flags = 516;
+        let mut flags = Vec::new();
+
         let (_, results) =
-            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags).unwrap();
+            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags, &mut flags)
+                .unwrap();
         assert!(results.shared_cache);
+        assert_eq!(flags, vec![MessageFlags::SharedCache]);
     }
 
     #[test]
@@ -171,10 +203,14 @@ mod tests {
             0, 78, 79, 0,
         ];
         let test_flags = 8;
+        let mut flags = Vec::new();
+
         let (_, results) =
-            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags).unwrap();
+            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags, &mut flags)
+                .unwrap();
         assert!(results.absolute);
         assert_eq!(results.main_exe_alt_index, 65408);
+        assert_eq!(flags, vec![MessageFlags::Absolute, MessageFlags::AltIndex]);
     }
 
     #[test]
@@ -183,8 +219,12 @@ mod tests {
             123, 13, 55, 117, 241, 144, 62, 33, 186, 19, 4, 71, 196, 27, 135, 67, 0, 0,
         ];
         let test_flags = 0xa;
+        let mut flags = Vec::new();
+
         let (_, results) =
-            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags).unwrap();
+            FirehoseFormatters::firehose_formatter_flags(&test_data, test_flags, &mut flags)
+                .unwrap();
         assert_eq!(results.uuid_relative, "7B0D3775F1903E21BA130447C41B8743");
+        assert_eq!(flags, vec![MessageFlags::UuidRelative]);
     }
 }

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -6,6 +6,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use crate::catalog::CatalogChunk;
+use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
 use crate::traits::FileProvider;
@@ -24,6 +25,7 @@ pub struct FirehoseNonActivity {
     pub data_ref_value: u32,         // if flag 0x0800, has_oversize
     pub pc_id: u32, // Appears to be used to calculate string offset for firehose events with Absolute flag
     pub firehose_formatters: FirehoseFormatters,
+    pub flags: Vec<MessageFlags>,
 }
 
 impl FirehoseNonActivity {
@@ -44,6 +46,7 @@ impl FirehoseNonActivity {
             let (firehose_input, firehose_unknown_sentinel) = le_u32(firehose_input)?;
             non_activity.activity_id = firehose_activity_id;
             non_activity.sentinal = firehose_unknown_sentinel;
+            non_activity.flags.push(MessageFlags::HasCurrentAid);
             input = firehose_input;
         }
 
@@ -53,6 +56,7 @@ impl FirehoseNonActivity {
             debug!("[macos-unifiedlogs] Non-Activity Firehose log chunk has has_private_data flag");
             let (firehose_input, firehose_private_strings_offset) = le_u16(input)?;
             let (firehose_input, firehose_private_strings_size) = le_u16(firehose_input)?;
+            non_activity.flags.push(MessageFlags::HasPrivateData);
 
             // Offset points to private string values found after parsing the public data. Size is the data size
             non_activity.private_strings_offset = firehose_private_strings_offset;
@@ -64,8 +68,11 @@ impl FirehoseNonActivity {
         non_activity.pc_id = firehose_pc_id;
 
         // Check for flags related to base string format location (shared string file (dsc) or UUID file)
-        let (mut input, formatters) =
-            FirehoseFormatters::firehose_formatter_flags(input, firehose_flags)?;
+        let (mut input, formatters) = FirehoseFormatters::firehose_formatter_flags(
+            input,
+            firehose_flags,
+            &mut non_activity.flags,
+        )?;
         non_activity.firehose_formatters = formatters;
 
         let subsystem = 0x200; // has_subsystem flag. In Non-Activity log entries this is the subsystem flag
@@ -74,6 +81,7 @@ impl FirehoseNonActivity {
             let (firehose_input, firehose_subsystem) = le_u16(input)?;
             non_activity.subsystem_value = firehose_subsystem;
             input = firehose_input;
+            non_activity.flags.push(MessageFlags::HasSubsystem);
         }
 
         let ttl = 0x400; // has_rules flag
@@ -81,6 +89,8 @@ impl FirehoseNonActivity {
             debug!("[macos-unifiedlogs] Non-Activity Firehose log chunk has has_rules flag");
             let (firehose_input, firehose_ttl) = le_u8(input)?;
             non_activity.ttl_value = firehose_ttl;
+            non_activity.flags.push(MessageFlags::HasRules);
+
             input = firehose_input;
         }
 
@@ -89,6 +99,8 @@ impl FirehoseNonActivity {
             debug!("[macos-unifiedlogs] Non-Activity Firehose log chunk has has_oversize flag");
             let (firehose_input, firehose_data_ref) = le_u32(input)?;
             non_activity.data_ref_value = firehose_data_ref;
+            non_activity.flags.push(MessageFlags::HasOversize);
+
             input = firehose_input;
         }
 

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -6,6 +6,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use crate::catalog::CatalogChunk;
+use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
 use crate::traits::FileProvider;
@@ -25,6 +26,7 @@ pub struct FirehoseSignpost {
     pub ttl_value: u8,
     pub data_ref_value: u32, // if flag 0x0800, has_oversize
     pub firehose_formatters: FirehoseFormatters,
+    pub flags: Vec<MessageFlags>,
 }
 
 impl FirehoseSignpost {
@@ -46,6 +48,7 @@ impl FirehoseSignpost {
             firehose_signpost.activity_id = firehose_activity_id;
             firehose_signpost.sentinel = firehose_sentinel;
             input = firehose_input;
+            firehose_signpost.flags.push(MessageFlags::HasCurrentAid);
         }
 
         let private_string_range = 0x100; // has_private_data flag
@@ -59,14 +62,18 @@ impl FirehoseSignpost {
             firehose_signpost.private_strings_offset = firehose_private_strings_offset;
             firehose_signpost.private_strings_size = firehose_private_strings_size;
             input = firehose_input;
+            firehose_signpost.flags.push(MessageFlags::HasPrivateData);
         }
 
         let (input, firehose_pc_id) = le_u32(input)?;
         firehose_signpost.pc_id = firehose_pc_id;
 
         // Check for flags related to base string format location (shared string file (dsc) or UUID file)
-        let (mut input, formatters) =
-            FirehoseFormatters::firehose_formatter_flags(input, firehose_flags)?;
+        let (mut input, formatters) = FirehoseFormatters::firehose_formatter_flags(
+            input,
+            firehose_flags,
+            &mut firehose_signpost.flags,
+        )?;
         firehose_signpost.firehose_formatters = formatters;
 
         let subsystem = 0x200; // has_subsystem flag. In Signpost log entries this is the subsystem flag
@@ -75,6 +82,7 @@ impl FirehoseSignpost {
             let (firehose_input, firehose_subsystem) = le_u16(input)?;
             firehose_signpost.subsystem = firehose_subsystem;
             input = firehose_input;
+            firehose_signpost.flags.push(MessageFlags::HasSubsystem);
         }
         let (mut input, firehose_signpost_id) = le_u64(input)?;
         firehose_signpost.signpost_id = firehose_signpost_id;
@@ -85,6 +93,7 @@ impl FirehoseSignpost {
             let (firehose_input, firehose_ttl) = le_u8(input)?;
             firehose_signpost.ttl_value = firehose_ttl;
             input = firehose_input;
+            firehose_signpost.flags.push(MessageFlags::HasRules);
         }
 
         let data_ref = 0x800; // has_oversize flag
@@ -93,6 +102,7 @@ impl FirehoseSignpost {
             let (firehose_input, firehose_data_ref) = le_u32(input)?;
             firehose_signpost.data_ref_value = firehose_data_ref;
             input = firehose_input;
+            firehose_signpost.flags.push(MessageFlags::HasOversize);
         }
 
         let has_name = 0x8000;

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -13,7 +13,9 @@ use std::collections::HashMap;
 
 use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::activity::FirehoseActivity;
-use crate::chunks::firehose::firehose_log::{Firehose, FirehoseItemType, FirehosePreamble};
+use crate::chunks::firehose::firehose_log::{
+    Firehose, FirehoseItemType, FirehosePreamble, MessageFlags,
+};
 use crate::chunks::firehose::nonactivity::FirehoseNonActivity;
 use crate::chunks::firehose::signpost::FirehoseSignpost;
 use crate::chunks::firehose::trace::FirehoseTrace;
@@ -216,6 +218,7 @@ impl Iterator for LogIterator<'_> {
                     process_uuid: String::new(),
                     raw_message: String::new(),
                     message_entries: firehose.message.item_info.to_owned(),
+                    message_flags: Vec::new(),
                     evidence: self.unified_log_data.evidence.clone(),
                 };
 
@@ -236,6 +239,7 @@ impl Iterator for LogIterator<'_> {
                             preamble.second_number_proc_id,
                             &catalog_data.catalog,
                         );
+                        log_data.message_flags = firehose.firehose_non_activity.flags.clone();
 
                         match message_data {
                             Ok((_, results)) => {
@@ -334,6 +338,7 @@ impl Iterator for LogIterator<'_> {
                             log_data.activity_id =
                                 u64::from(firehose.firehose_activity.activity_id);
                         }
+                        log_data.message_flags = firehose.firehose_activity.flags.clone();
                         let message_data = FirehoseActivity::get_firehose_activity_strings(
                             &firehose.firehose_activity,
                             self.provider,
@@ -388,6 +393,7 @@ impl Iterator for LogIterator<'_> {
                     }
                     0x6 => {
                         log_data.activity_id = u64::from(firehose.firehose_signpost.activity_id);
+                        log_data.message_flags = firehose.firehose_signpost.flags.clone();
                         let message_data = FirehoseSignpost::get_firehose_signpost(
                             &firehose.firehose_signpost,
                             self.provider,
@@ -570,6 +576,7 @@ impl Iterator for LogIterator<'_> {
                 process_uuid: simpledump.dsc_uuid.to_owned(),
                 raw_message: String::new(),
                 message_entries: Vec::new(),
+                message_flags: Vec::new(),
                 evidence: self.unified_log_data.evidence.clone(),
             };
             log_data_vec.push(log_data);
@@ -644,6 +651,7 @@ impl Iterator for LogIterator<'_> {
                 process_uuid: String::new(),
                 raw_message: String::new(),
                 message_entries: Vec::new(),
+                message_flags: Vec::new(),
                 evidence: self.unified_log_data.evidence.clone(),
             };
             log_data_vec.push(log_data);
@@ -676,6 +684,7 @@ pub struct LogData {
     pub timezone_name: String,
     pub message_entries: Vec<FirehoseItemType>,
     pub timestamp: String,
+    pub message_flags: Vec<MessageFlags>,
     pub evidence: String,
 }
 


### PR DESCRIPTION
Added message flags to output results as `message_flags` field. Mostly helpful when comparing against `log raw-dump` output

Ex: `shared_cache`, `absolute`, etc

```json
{
    "subsystem": "com.apple.xpc.activity",
    "thread_id": 1448470,
    "pid": 1343,
    "euid": 501,
    "library": "/usr/lib/system/libxpc.dylib",
    "library_uuid": "0CEC3289F16635F68CEFDE3D17EB0228",
    "activity_id": 0,
    "parent_activity_id": 0,
    "time": 1776661433759124500,
    "category": "Client",
    "event_type": "Log",
    "log_type": "Default",
    "process": "/Applications/DuckDuckGo.app/Contents/Library/LoginItems/DuckDuckGo Personal Information Removal.app/Contents/MacOS/DuckDuckGo Personal Information Removal",
    "process_uuid": "2D150BEB3FF631B69B533FB17E616220",
    "message": "_xpc_activity_begin_running: com.duckduckgo.macos.browser.databroker-protection-scheduler (C47D20280) seqno: 1.",
    "raw_message": "_xpc_activity_begin_running: %{public}s (%p) seqno: %llu.",
    "boot_uuid": "283F8A50A39743DCA1129F8041418D7F",
    "timezone_name": "New_York",
    "message_entries": [
        {
            "item_type": 34,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 61,
            "message_strings": "com.duckduckgo.macos.browser.databroker-protection-scheduler",
            "item": "String"
        },
        {
            "item_type": 0,
            "item_type_size": 8,
            "offset": 0,
            "item_size": 0,
            "message_strings": "52744553088",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 8,
            "offset": 0,
            "item_size": 0,
            "message_strings": "1",
            "item": "Number"
        }
    ],
    "timestamp": "2026-04-20T05:03:53.759124480Z”,
    "message_flags": [
        "SharedCache",
        "HasSubsystem"
    ],
    "evidence": "system_logs.logarchive/Persist/00000000000007ad.tracev3"
}
```