### PR TITLE
Sort all fileproviders outputs

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -112,7 +112,7 @@ impl From<&Path> for LogFileType {
 impl FileProvider for LiveSystemProvider {
     fn tracev3_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/diagnostics");
-        sort_source_files(
+        sort_files(
             WalkDir::new(path)
                 .sort_by(|a, b| a.file_name().cmp(b.file_name()))
                 .into_iter()
@@ -126,7 +126,7 @@ impl FileProvider for LiveSystemProvider {
 
     fn uuidtext_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/uuidtext");
-        sort_source_files(
+        sort_files(
             WalkDir::new(path)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -277,7 +277,7 @@ impl FileProvider for LiveSystemProvider {
 
     fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/uuidtext/dsc");
-        sort_source_files(WalkDir::new(path).into_iter().filter_map(|entry| {
+        sort_files(WalkDir::new(path).into_iter().filter_map(|entry| {
             if !matches!(
                 LogFileType::from(entry.as_ref().ok()?.path()),
                 LogFileType::Dsc
@@ -290,7 +290,7 @@ impl FileProvider for LiveSystemProvider {
 
     fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/diagnostics/timesync");
-        sort_source_files(
+        sort_files(
             WalkDir::new(path)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -346,7 +346,7 @@ impl FileProvider for LogarchiveProvider {
     ///    }
     /// ```
     fn tracev3_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_source_files(
+        sort_files(
             WalkDir::new(&self.base)
                 .sort_by(|a, b| a.file_name().cmp(b.file_name()))
                 .into_iter()
@@ -359,7 +359,7 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn uuidtext_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_source_files(
+        sort_files(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -466,7 +466,7 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_source_files(
+        sort_files(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -521,7 +521,7 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_source_files(
+        sort_files(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -533,7 +533,11 @@ impl FileProvider for LogarchiveProvider {
     }
 }
 
-fn sort_source_files(
+/// Sort files by their source path, 
+/// in order to have deterministic output of the parser.
+/// Not having it would cause parsing differences across systems 
+/// (macOS does not guarantee order of files returned by the filesystem).
+fn sort_files(
     files: impl Iterator<Item = Box<dyn SourceFile>>,
 ) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
     let mut files = files.collect::<Vec<_>>();

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -533,9 +533,9 @@ impl FileProvider for LogarchiveProvider {
     }
 }
 
-/// Sort files by their source path, 
+/// Sort files by their source path,
 /// in order to have deterministic output of the parser.
-/// Not having it would cause parsing differences across systems 
+/// Not having it would cause parsing differences across systems
 /// (macOS does not guarantee order of files returned by the filesystem).
 fn sort_files(
     files: impl Iterator<Item = Box<dyn SourceFile>>,

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -112,7 +112,7 @@ impl From<&Path> for LogFileType {
 impl FileProvider for LiveSystemProvider {
     fn tracev3_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/diagnostics");
-        Box::new(
+        sort_source_files(
             WalkDir::new(path)
                 .sort_by(|a, b| a.file_name().cmp(b.file_name()))
                 .into_iter()
@@ -126,7 +126,7 @@ impl FileProvider for LiveSystemProvider {
 
     fn uuidtext_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/uuidtext");
-        Box::new(
+        sort_source_files(
             WalkDir::new(path)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -277,7 +277,7 @@ impl FileProvider for LiveSystemProvider {
 
     fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/uuidtext/dsc");
-        Box::new(WalkDir::new(path).into_iter().filter_map(|entry| {
+        sort_source_files(WalkDir::new(path).into_iter().filter_map(|entry| {
             if !matches!(
                 LogFileType::from(entry.as_ref().ok()?.path()),
                 LogFileType::Dsc
@@ -290,7 +290,7 @@ impl FileProvider for LiveSystemProvider {
 
     fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         let path = PathBuf::from("/private/var/db/diagnostics/timesync");
-        Box::new(
+        sort_source_files(
             WalkDir::new(path)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -346,7 +346,7 @@ impl FileProvider for LogarchiveProvider {
     ///    }
     /// ```
     fn tracev3_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        Box::new(
+        sort_source_files(
             WalkDir::new(&self.base)
                 .sort_by(|a, b| a.file_name().cmp(b.file_name()))
                 .into_iter()
@@ -359,7 +359,7 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn uuidtext_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        Box::new(
+        sort_source_files(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -466,7 +466,7 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        Box::new(
+        sort_source_files(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -521,7 +521,7 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        Box::new(
+        sort_source_files(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -531,6 +531,14 @@ impl FileProvider for LogarchiveProvider {
                 }),
         )
     }
+}
+
+fn sort_source_files(
+    files: impl Iterator<Item = Box<dyn SourceFile>>,
+) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
+    let mut files = files.collect::<Vec<_>>();
+    files.sort_by(|a, b| a.source_path().cmp(b.source_path()));
+    Box::new(files.into_iter())
 }
 
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -345,7 +345,7 @@ mod tests {
         assert_eq!(shared_strings_results[0].major_version, 1);
         assert_eq!(shared_strings_results[0].ranges.len(), 788);
         assert_eq!(shared_strings_results[0].uuids.len(), 532);
-        
+
         assert_eq!(shared_strings_results.len(), 2);
         assert_eq!(shared_strings_results[1].number_uuids, 1976);
         assert_eq!(shared_strings_results[1].number_ranges, 2993);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -334,17 +334,29 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
         let shared_strings_results = collect_shared_strings(&provider).unwrap();
-        assert_eq!(shared_strings_results.len(), 2);
-        assert_eq!(shared_strings_results[0].number_uuids, 1976);
-        assert_eq!(shared_strings_results[0].number_ranges, 2993);
+
+        assert_eq!(shared_strings_results[0].number_uuids, 532);
+        assert_eq!(shared_strings_results[0].number_ranges, 788);
         assert_eq!(
             shared_strings_results[0].dsc_uuid,
-            "80896B329EB13A10A7C5449B15305DE2"
+            "522F6217CB113F8FB845C2A1B784C7C2"
         );
         assert_eq!(shared_strings_results[0].minor_version, 0);
         assert_eq!(shared_strings_results[0].major_version, 1);
-        assert_eq!(shared_strings_results[0].ranges.len(), 2993);
-        assert_eq!(shared_strings_results[0].uuids.len(), 1976);
+        assert_eq!(shared_strings_results[0].ranges.len(), 788);
+        assert_eq!(shared_strings_results[0].uuids.len(), 532);
+        
+        assert_eq!(shared_strings_results.len(), 2);
+        assert_eq!(shared_strings_results[1].number_uuids, 1976);
+        assert_eq!(shared_strings_results[1].number_ranges, 2993);
+        assert_eq!(
+            shared_strings_results[1].dsc_uuid,
+            "80896B329EB13A10A7C5449B15305DE2"
+        );
+        assert_eq!(shared_strings_results[1].minor_version, 0);
+        assert_eq!(shared_strings_results[1].major_version, 1);
+        assert_eq!(shared_strings_results[1].ranges.len(), 2993);
+        assert_eq!(shared_strings_results[1].uuids.len(), 1976);
     }
 
     #[test]


### PR DESCRIPTION
Hello,

We had a weird difference in our parsers since a very long time, and I finally took the time to go down the rabbit hole.

So we had subtle differences in the timestamps provided by the global iterator in logdata.

In the end, it was, in rare cases, files order provided by the fileprovider, could have an influence on the timesync data provided to the iterator, and so the boot time was differente (slightly) and so the timestamps were not the same.

This PR is fixing it, it's more deterministic now