### PR TITLE
Refactor: cache decoupling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.22.1"
 chrono = "0.4.44"
 walkdir = "2.5.0"
 sunlight = "0.1.5"
+cached = "0.59.0"
 
 [dev-dependencies]
 chrono = "0.4.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ base64 = "0.22.1"
 chrono = "0.4.44"
 walkdir = "2.5.0"
 sunlight = "0.1.5"
-cached = "0.59.0"
 
 [dev-dependencies]
 chrono = "0.4.44"

--- a/benches/big_sur_benchmark.rs
+++ b/benches/big_sur_benchmark.rs
@@ -57,7 +57,15 @@ fn big_sur_build_log_benchbress(c: &mut Criterion) {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     c.bench_function("Benching Building One Big Sur Log", |b| {
-        b.iter(|| bench_build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing));
+        b.iter(|| {
+            bench_build_log(
+                &log_data,
+                &provider,
+                &cache,
+                &timesync_data,
+                exclude_missing,
+            )
+        });
     });
 }
 

--- a/benches/big_sur_benchmark.rs
+++ b/benches/big_sur_benchmark.rs
@@ -46,8 +46,9 @@ fn big_sur_build_log_benchbress(c: &mut Criterion) {
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
+
+    let cache = MemoryStringCache::default();
 
     test_path.push("Persist/0000000000000004.tracev3");
     let exclude_missing = false;
@@ -56,15 +57,7 @@ fn big_sur_build_log_benchbress(c: &mut Criterion) {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     c.bench_function("Benching Building One Big Sur Log", |b| {
-        b.iter(|| {
-            bench_build_log(
-                &log_data,
-                &provider,
-                &cache,
-                &timesync_data,
-                exclude_missing,
-            )
-        });
+        b.iter(|| bench_build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing));
     });
 }
 

--- a/benches/big_sur_benchmark.rs
+++ b/benches/big_sur_benchmark.rs
@@ -7,10 +7,11 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use macos_unifiedlogs::{
+    cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     timesync::TimesyncBoot,
-    traits::FileProvider,
+    traits::{FileProvider, StringCache},
     unified_log::UnifiedLogData,
 };
 use std::{collections::HashMap, fs::File, path::PathBuf};
@@ -22,11 +23,12 @@ fn big_sur_parse_log(path: &str) {
 
 fn bench_build_log(
     log_data: &UnifiedLogData,
-    provider: &mut dyn FileProvider,
+    provider: &impl FileProvider,
+    cache: &impl StringCache,
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) {
-    let (_, _) = build_log(log_data, provider, timesync_data, exclude_missing);
+    let (_, _) = build_log(log_data, provider, cache, timesync_data, exclude_missing);
 }
 
 fn big_sur_single_log_benchpress(c: &mut Criterion) {
@@ -35,7 +37,7 @@ fn big_sur_single_log_benchpress(c: &mut Criterion) {
         .push("tests/test_data/system_logs_big_sur.logarchive/Persist/0000000000000004.tracev3");
 
     c.bench_function("Benching Parsing One Big Sur Log", |b| {
-        b.iter(|| big_sur_parse_log(&test_path.display().to_string()))
+        b.iter(|| big_sur_parse_log(&test_path.display().to_string()));
     });
 }
 
@@ -43,17 +45,26 @@ fn big_sur_build_log_benchbress(c: &mut Criterion) {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000004.tracev3");
     let exclude_missing = false;
-    let handle = File::open(&test_path.as_path()).unwrap();
+    let handle = File::open(test_path.as_path()).unwrap();
 
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     c.bench_function("Benching Building One Big Sur Log", |b| {
-        b.iter(|| bench_build_log(&log_data, &mut provider, &timesync_data, exclude_missing))
+        b.iter(|| {
+            bench_build_log(
+                &log_data,
+                &provider,
+                &cache,
+                &timesync_data,
+                exclude_missing,
+            )
+        });
     });
 }
 

--- a/benches/high_sierra_benchmark.rs
+++ b/benches/high_sierra_benchmark.rs
@@ -7,11 +7,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use macos_unifiedlogs::{
-    filesystem::LogarchiveProvider,
-    parser::{build_log, collect_timesync, parse_log},
-    timesync::TimesyncBoot,
-    traits::FileProvider,
-    unified_log::UnifiedLogData,
+    cache::MemoryStringCache, filesystem::LogarchiveProvider, parser::{build_log, collect_timesync, parse_log}, timesync::TimesyncBoot, traits::{FileProvider, StringCache}, unified_log::UnifiedLogData
 };
 use std::{collections::HashMap, fs::File, path::PathBuf};
 
@@ -22,11 +18,12 @@ fn high_sierra_parse_log(path: &str) {
 
 fn bench_build_log(
     log_data: &UnifiedLogData,
-    provider: &mut dyn FileProvider,
+    provider: &impl FileProvider,
+    cache: &impl StringCache,
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) {
-    let (_, _) = build_log(log_data, provider, timesync_data, exclude_missing);
+    let (_, _) = build_log(log_data, provider, cache, timesync_data, exclude_missing);
 }
 
 fn high_sierra_single_log_benchpress(c: &mut Criterion) {
@@ -36,24 +33,25 @@ fn high_sierra_single_log_benchpress(c: &mut Criterion) {
     );
 
     c.bench_function("Benching Parsing One High Sierra Log", |b| {
-        b.iter(|| high_sierra_parse_log(&test_path.display().to_string()))
+        b.iter(|| high_sierra_parse_log(&test_path.display().to_string()));
     });
 }
 
 fn high_sierra_build_log_benchbress(c: &mut Criterion) {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000002.tracev3");
     let exclude_missing = false;
-    let handle = File::open(&test_path.as_path()).unwrap();
+    let handle = File::open(test_path.as_path()).unwrap();
 
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     c.bench_function("Benching Building One High Sierra Log", |b| {
-        b.iter(|| bench_build_log(&log_data, &mut provider, &timesync_data, exclude_missing))
+        b.iter(|| bench_build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing));
     });
 }
 

--- a/benches/high_sierra_benchmark.rs
+++ b/benches/high_sierra_benchmark.rs
@@ -7,7 +7,12 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use macos_unifiedlogs::{
-    cache::MemoryStringCache, filesystem::LogarchiveProvider, parser::{build_log, collect_timesync, parse_log}, timesync::TimesyncBoot, traits::{FileProvider, StringCache}, unified_log::UnifiedLogData
+    cache::MemoryStringCache,
+    filesystem::LogarchiveProvider,
+    parser::{build_log, collect_timesync, parse_log},
+    timesync::TimesyncBoot,
+    traits::{FileProvider, StringCache},
+    unified_log::UnifiedLogData,
 };
 use std::{collections::HashMap, fs::File, path::PathBuf};
 
@@ -51,7 +56,15 @@ fn high_sierra_build_log_benchbress(c: &mut Criterion) {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     c.bench_function("Benching Building One High Sierra Log", |b| {
-        b.iter(|| bench_build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing));
+        b.iter(|| {
+            bench_build_log(
+                &log_data,
+                &provider,
+                &cache,
+                &timesync_data,
+                exclude_missing,
+            );
+        });
     });
 }
 

--- a/benches/monterey_benchmark.rs
+++ b/benches/monterey_benchmark.rs
@@ -45,8 +45,8 @@ fn monterey_build_log_benchbress(c: &mut Criterion) {
     test_path.push("tests/test_data/system_logs_monterey.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
+    let cache = MemoryStringCache::default();
 
     test_path.push("Persist/0000000000000004.tracev3");
     let exclude_missing = false;

--- a/benches/monterey_benchmark.rs
+++ b/benches/monterey_benchmark.rs
@@ -7,10 +7,11 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use macos_unifiedlogs::{
+    cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     timesync::TimesyncBoot,
-    traits::FileProvider,
+    traits::{FileProvider, StringCache},
     unified_log::UnifiedLogData,
 };
 use std::{collections::HashMap, fs::File, path::PathBuf};
@@ -21,11 +22,12 @@ fn monterey_parse_log(path: &str) {
 
 fn bench_build_log(
     log_data: &UnifiedLogData,
-    provider: &mut dyn FileProvider,
+    provider: &impl FileProvider,
+    cache: &impl StringCache,
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) {
-    let (_, _) = build_log(log_data, provider, timesync_data, exclude_missing);
+    let (_, _) = build_log(log_data, provider, cache, timesync_data, exclude_missing);
 }
 
 fn monterey_single_log_benchpress(c: &mut Criterion) {
@@ -34,7 +36,7 @@ fn monterey_single_log_benchpress(c: &mut Criterion) {
         .push("tests/test_data/system_logs_monterey.logarchive/Persist/0000000000000004.tracev3");
 
     c.bench_function("Benching Parsing One Monterey Log", |b| {
-        b.iter(|| monterey_parse_log(&test_path.display().to_string()))
+        b.iter(|| monterey_parse_log(&test_path.display().to_string()));
     });
 }
 
@@ -42,17 +44,26 @@ fn monterey_build_log_benchbress(c: &mut Criterion) {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_monterey.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000004.tracev3");
     let exclude_missing = false;
-    let handle = File::open(&test_path.as_path()).unwrap();
+    let handle = File::open(test_path.as_path()).unwrap();
 
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     c.bench_function("Benching Building One Monterey Log", |b| {
-        b.iter(|| bench_build_log(&log_data, &mut provider, &timesync_data, exclude_missing))
+        b.iter(|| {
+            bench_build_log(
+                &log_data,
+                &provider,
+                &cache,
+                &timesync_data,
+                exclude_missing,
+            );
+        });
     });
 }
 

--- a/examples/unifiedlog_iterator/src/main.rs
+++ b/examples/unifiedlog_iterator/src/main.rs
@@ -6,13 +6,13 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use chrono::{SecondsFormat, TimeZone, Utc};
-use log::{debug, error, info, warn, LevelFilter};
+use log::{LevelFilter, debug, error, info, warn};
 use macos_unifiedlogs::cache::MemoryStringCache;
 use macos_unifiedlogs::filesystem::{LiveSystemProvider, LogarchiveProvider};
 use macos_unifiedlogs::iterator::UnifiedLogIterator;
 use macos_unifiedlogs::parser::{build_log, collect_timesync, parse_log};
 use macos_unifiedlogs::timesync::TimesyncBoot;
-use macos_unifiedlogs::traits::{FileProvider, StringCache};
+use macos_unifiedlogs::traits::{FileProvider, SourceFile, StringCache};
 use macos_unifiedlogs::unified_log::{LogData, UnifiedLogData};
 use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
 use std::collections::HashMap;
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use clap::{builder, Parser, ValueEnum};
+use clap::{Parser, ValueEnum, builder};
 use csv::Writer;
 
 /// Global atomic flag to track SIGINT signal
@@ -90,7 +90,9 @@ fn filter_and_update_bookmark(
         .collect();
 
     // Update bookmark with max timestamp seen (not just filtered) to avoid re-scanning
-    if let Some(max_time) = max_seen_timestamp && let Ok(mut book) = bookmark.lock() {
+    if let Some(max_time) = max_seen_timestamp
+        && let Ok(mut book) = bookmark.lock()
+    {
         book.update_timestamp(max_time);
     }
 
@@ -209,8 +211,7 @@ fn main() {
     // Determine source ID for bookmark
     let source_id = match (&args.mode, &args.input) {
         (Mode::Live, _) => "live".to_string(),
-        (Mode::LogArchive, Some(path)) => path.to_string_lossy().to_string(),
-        (Mode::SingleFile, Some(path)) => path.to_string_lossy().to_string(),
+        (Mode::LogArchive | Mode::SingleFile, Some(path)) => path.to_string_lossy().to_string(),
         _ => "unknown".to_string(),
     };
 
@@ -220,11 +221,17 @@ fn main() {
         .clone()
         .unwrap_or_else(|| Bookmark::default_path(&mode_str));
 
-    info!("Using bookmark path: {path:?}", path = bookmark_path);
+    info!(
+        "Using bookmark path: {path}",
+        path = bookmark_path.display()
+    );
 
     let mut bookmark = if args.resume {
         Bookmark::load_bookmark(&bookmark_path).unwrap_or_else(|| {
-            info!("Creating new bookmark at {path:?}", path = bookmark_path);
+            info!(
+                "Creating new bookmark at {path}",
+                path = bookmark_path.display()
+            );
             Bookmark::new(source_id.clone())
         })
     } else {
@@ -277,7 +284,8 @@ fn main() {
             parse_log_archive(&path, &mut writer, Arc::clone(&bookmark), resume)
         }
         (Mode::SingleFile, Some(path)) => {
-            parse_single_file(&path, &mut writer, Arc::clone(&bookmark), resume)
+            parse_single_file(&path, &mut writer, Arc::clone(&bookmark), resume);
+            Ok(())
         }
         _ => {
             error!("log-archive and single-file modes require an --input argument");
@@ -291,13 +299,15 @@ fn main() {
         match bookmark.lock() {
             Ok(bookmark) => {
                 if let Err(e) = bookmark.save_bookmark(&bookmark_path) {
-                    eprintln!("Failed to save bookmark on interrupt: {error}", error = e);
+                    eprintln!("Failed to save bookmark on interrupt: {e}");
                 } else {
-                    eprintln!("Bookmark saved to {path:?}", path = bookmark_path);
+                    eprintln!("Bookmark saved to {path}", path = bookmark_path.display());
                 }
             }
             Err(_) => {
-                eprintln!("Warning: Could not acquire bookmark lock (mutex poisoned). Bookmark not saved.");
+                eprintln!(
+                    "Warning: Could not acquire bookmark lock (mutex poisoned). Bookmark not saved."
+                );
             }
         }
         std::process::exit(0);
@@ -308,9 +318,9 @@ fn main() {
         match bookmark.lock() {
             Ok(bookmark) => {
                 if let Err(e) = bookmark.save_bookmark(&bookmark_path) {
-                    error!("Failed to save bookmark: {error}", error = e);
+                    error!("Failed to save bookmark: {e}");
                 } else {
-                    info!("Bookmark saved to {path:?}", path = bookmark_path);
+                    info!("Bookmark saved to {path}", path = bookmark_path.display());
                 }
             }
             Err(_) => {
@@ -320,7 +330,7 @@ fn main() {
     }
 
     if let Err(e) = result {
-        error!("Error during parsing: {error}", error = e);
+        error!("Error during parsing: {e}");
     }
 }
 
@@ -329,7 +339,7 @@ fn parse_single_file(
     writer: &mut OutputWriter,
     bookmark: Arc<Mutex<Bookmark>>,
     resume: bool,
-) -> Result<(), Box<dyn Error>> {
+) {
     let mut provider = LogarchiveProvider::new(path);
     let results = match fs::File::open(path)
         .map_err(|e| RuntimeError::FileOpen {
@@ -337,19 +347,27 @@ fn parse_single_file(
             message: e.to_string(),
         })
         .and_then(|mut reader| {
-            parse_log(&mut reader, path.to_str().unwrap_or_default()).map_err(|err| RuntimeError::FileParse {
-                path: path.to_string_lossy().to_string(),
-                message: format!("{err}"),
+            parse_log(&mut reader, path.to_str().unwrap_or_default()).map_err(|err| {
+                RuntimeError::FileParse {
+                    path: path.to_string_lossy().to_string(),
+                    message: format!("{err}"),
+                }
             })
         })
         .map(|ref log| {
-            let (results, _) = build_log(log, &mut provider, &HashMap::new(), false);
+            let (results, _) = build_log(
+                log,
+                &mut provider,
+                &MemoryStringCache::default(),
+                &HashMap::new(),
+                false,
+            );
             results
         }) {
         Ok(reader) => reader,
         Err(e) => {
             error!("Failed to parse {path:?}: {error}", path = path, error = e);
-            return Ok(());
+            return;
         }
     };
 
@@ -380,7 +398,9 @@ fn parse_single_file(
         }
 
         // Update bookmark with max timestamp seen (not just written) to avoid re-scanning
-        if max_seen_timestamp > 0.0 && let Ok(mut bookmark) = bookmark.lock() {
+        if max_seen_timestamp > 0.0
+            && let Ok(mut bookmark) = bookmark.lock()
+        {
             bookmark.update_timestamp(max_seen_timestamp);
         }
     } else {
@@ -399,7 +419,6 @@ fn parse_single_file(
         written = count,
         skipped = total_count - count
     );
-    Ok(())
 }
 
 // Parse a provided directory path. Currently, expect the path to follow macOS log collect structure
@@ -416,7 +435,14 @@ fn parse_log_archive(
 
     // Keep UUID, UUID cache, timesync files in memory while we parse all tracev3 files
     // Allows for faster lookups
-    match parse_trace_file(&timesync_data, &mut provider, writer, bookmark, resume) {
+    match parse_trace_file(
+        &timesync_data,
+        &mut provider,
+        &MemoryStringCache::default(),
+        writer,
+        bookmark,
+        resume,
+    ) {
         Ok(()) => {
             info!("Finished parsing Unified Log data.");
             Ok(())
@@ -434,7 +460,7 @@ fn parse_live_system(
     bookmark: Arc<Mutex<Bookmark>>,
     resume: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let mut provider = LiveSystemProvider::default();
+    let provider = LiveSystemProvider::default();
     let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -469,10 +495,7 @@ fn parse_trace_file(
         },
     };
     let resume_timestamp = if resume {
-        bookmark
-            .lock()
-            .map(|b| b.last_timestamp)
-            .unwrap_or(0.0)
+        bookmark.lock().map(|b| b.last_timestamp).unwrap_or(0.0)
     } else {
         0.0
     };
@@ -503,7 +526,7 @@ fn parse_trace_file(
         }
         info!("Parsing: {path}", path = source.source_path());
         let path = source.source_path().to_string();
-        match iterate_chunks(
+        if let Ok((new_count, new_skipped)) = iterate_chunks(
             source.reader(),
             provider,
             cache,
@@ -512,19 +535,12 @@ fn parse_trace_file(
             &mut parse_context,
             path,
         ) {
-            Ok((new_count, new_skipped)) => {
-                log_count += new_count;
-                skipped_count += new_skipped;
-                debug!(
-                    "count: {count}, skipped: {skipped}",
-                    count = log_count,
-                    skipped = skipped_count
-                );
-            }
-            Err(BrokenPipeError) => {
-                info!("Broken pipe detected, stopping log parsing");
-                return Err(BrokenPipeError);
-            }
+            log_count += new_count;
+            skipped_count += new_skipped;
+            debug!("count: {log_count}, skipped: {skipped_count}");
+        } else {
+            info!("Broken pipe detected, stopping log parsing");
+            return Err(BrokenPipeError);
         }
     }
     let include_missing = false;
@@ -542,12 +558,20 @@ fn parse_trace_file(
     let leftover_data = std::mem::take(&mut parse_context.context.missing_data);
     for mut leftover_data in leftover_data {
         // Add all of our previous oversize data to logs for lookups
-        leftover_data.oversize = parse_context.context.oversize_strings.oversize.clone();
+        leftover_data
+            .oversize
+            .clone_from(&parse_context.context.oversize_strings.oversize);
 
         // Exclude_missing = false
         // If we fail to find any missing data its probably due to the logs rolling
         // Ex: tracev3A rolls, tracev3B references Oversize entry in tracev3A will trigger missing data since tracev3A is gone
-        let (results, _) = build_log(&leftover_data, provider, cache, timesync_data, include_missing);
+        let (results, _) = build_log(
+            &leftover_data,
+            provider,
+            cache,
+            timesync_data,
+            include_missing,
+        );
 
         // Filter by bookmark and update bookmark with max timestamp seen
         let (filtered_results, new_skipped) = filter_and_update_bookmark(
@@ -569,11 +593,7 @@ fn parse_trace_file(
             log::error!("Failed to output remaining log data: {err:?}");
         }
     }
-    info!(
-        "Parsed {count} log entries (skipped {skipped} older entries)",
-        count = log_count,
-        skipped = skipped_count
-    );
+    info!("Parsed {log_count} log entries (skipped {skipped_count} older entries)");
     Ok(())
 }
 
@@ -615,7 +635,8 @@ fn iterate_chunks(
         chunk
             .oversize
             .append(&mut parse_context.context.oversize_strings.oversize);
-        let (results, missing_logs) = build_log(&chunk, provider, cache, timesync_data, exclude_missing);
+        let (results, missing_logs) =
+            build_log(&chunk, provider, cache, timesync_data, exclude_missing);
 
         // Filter by bookmark and update bookmark with max timestamp seen
         let (filtered_results, new_skipped) = filter_and_update_bookmark(
@@ -710,21 +731,21 @@ impl OutputWriter {
                     date_time.to_rfc3339_opts(SecondsFormat::Millis, true),
                     format!("{:?}", record.event_type),
                     format!("{:?}", record.log_type),
-                    record.subsystem.to_owned(),
+                    record.subsystem.clone(),
                     record.thread_id.to_string(),
                     record.pid.to_string(),
                     record.euid.to_string(),
-                    record.library.to_owned(),
-                    record.library_uuid.to_owned(),
+                    record.library.clone(),
+                    record.library_uuid.clone(),
                     record.activity_id.to_string(),
                     record.parent_activity_id.to_string(),
-                    record.category.to_owned(),
-                    record.process.to_owned(),
-                    record.process_uuid.to_owned(),
-                    record.message.to_owned(),
-                    record.raw_message.to_owned(),
-                    record.boot_uuid.to_owned(),
-                    record.timezone_name.to_owned(),
+                    record.category.clone(),
+                    record.process.clone(),
+                    record.process_uuid.clone(),
+                    record.message.clone(),
+                    record.raw_message.clone(),
+                    record.boot_uuid.clone(),
+                    record.timezone_name.clone(),
                 ])?;
             }
             OutputWriterEnum::Json(json_writer) => {

--- a/examples/unifiedlog_iterator/src/main.rs
+++ b/examples/unifiedlog_iterator/src/main.rs
@@ -7,11 +7,12 @@
 
 use chrono::{SecondsFormat, TimeZone, Utc};
 use log::{debug, error, info, warn, LevelFilter};
+use macos_unifiedlogs::cache::MemoryStringCache;
 use macos_unifiedlogs::filesystem::{LiveSystemProvider, LogarchiveProvider};
 use macos_unifiedlogs::iterator::UnifiedLogIterator;
 use macos_unifiedlogs::parser::{build_log, collect_timesync, parse_log};
 use macos_unifiedlogs::timesync::TimesyncBoot;
-use macos_unifiedlogs::traits::FileProvider;
+use macos_unifiedlogs::traits::{FileProvider, StringCache};
 use macos_unifiedlogs::unified_log::{LogData, UnifiedLogData};
 use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
 use std::collections::HashMap;
@@ -434,9 +435,10 @@ fn parse_live_system(
     resume: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut provider = LiveSystemProvider::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
-    match parse_trace_file(&timesync_data, &mut provider, writer, bookmark, resume) {
+    match parse_trace_file(&timesync_data, &provider, &cache, writer, bookmark, resume) {
         Ok(()) => {
             info!("Finished parsing Unified Log data.");
             Ok(())
@@ -451,7 +453,8 @@ fn parse_live_system(
 // Use the provided strings, shared strings, timesync data to parse the Unified Log data at provided path.
 fn parse_trace_file(
     timesync_data: &HashMap<String, TimesyncBoot>,
-    provider: &mut dyn FileProvider,
+    provider: &impl FileProvider,
+    cache: &impl StringCache,
     writer: &mut OutputWriter,
     bookmark: Arc<Mutex<Bookmark>>,
     resume: bool,
@@ -503,6 +506,7 @@ fn parse_trace_file(
         match iterate_chunks(
             source.reader(),
             provider,
+            cache,
             timesync_data,
             writer,
             &mut parse_context,
@@ -543,7 +547,7 @@ fn parse_trace_file(
         // Exclude_missing = false
         // If we fail to find any missing data its probably due to the logs rolling
         // Ex: tracev3A rolls, tracev3B references Oversize entry in tracev3A will trigger missing data since tracev3A is gone
-        let (results, _) = build_log(&leftover_data, provider, timesync_data, include_missing);
+        let (results, _) = build_log(&leftover_data, provider, cache, timesync_data, include_missing);
 
         // Filter by bookmark and update bookmark with max timestamp seen
         let (filtered_results, new_skipped) = filter_and_update_bookmark(
@@ -575,7 +579,8 @@ fn parse_trace_file(
 
 fn iterate_chunks(
     mut reader: impl Read,
-    provider: &mut dyn FileProvider,
+    provider: &impl FileProvider,
+    cache: &impl StringCache,
     timesync_data: &HashMap<String, TimesyncBoot>,
     writer: &mut OutputWriter,
     parse_context: &mut ParseContext,
@@ -610,7 +615,7 @@ fn iterate_chunks(
         chunk
             .oversize
             .append(&mut parse_context.context.oversize_strings.oversize);
-        let (results, missing_logs) = build_log(&chunk, provider, timesync_data, exclude_missing);
+        let (results, missing_logs) = build_log(&chunk, provider, cache, timesync_data, exclude_missing);
 
         // Filter by bookmark and update bookmark with max timestamp seen
         let (filtered_results, new_skipped) = filter_and_update_bookmark(

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,13 +1,10 @@
-use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use crate::dsc::SharedCacheStrings;
-use crate::traits::FileProvider;
-use crate::uuidtext::UUIDText;
+use cached::{Cached, SizedCache};
 
-const UUIDTEXT_CACHE_MAX: usize = 30;
-const UUIDTEXT_EVICT_COUNT: usize = 5;
-const DSC_CACHE_MAX: usize = 2;
+use crate::dsc::SharedCacheStrings;
+use crate::traits::{FileProvider, StringCache};
+use crate::uuidtext::UUIDText;
 
 /// A thread-safe cache for [`UUIDText`] and [`SharedCacheStrings`] data shared during log parsing.
 ///
@@ -37,30 +34,54 @@ const DSC_CACHE_MAX: usize = 2;
 ///     }
 /// });
 /// ```
-#[derive(Clone, Debug, Default)]
-pub struct StringCache {
-    uuidtext: Arc<RwLock<HashMap<String, Arc<UUIDText>>>>,
-    dsc: Arc<RwLock<HashMap<String, Arc<SharedCacheStrings>>>>,
+#[derive(Clone, Debug)]
+pub struct MemoryStringCache<
+    U: Cached<String, Arc<UUIDText>>,
+    D: Cached<String, Arc<SharedCacheStrings>>,
+> {
+    uuidtext: Arc<RwLock<U>>,
+    dsc: Arc<RwLock<D>>,
 }
 
-impl StringCache {
-    pub fn new() -> Self {
-        Self::default()
+impl Default
+    for MemoryStringCache<
+        SizedCache<String, Arc<UUIDText>>,
+        SizedCache<String, Arc<SharedCacheStrings>>,
+    >
+{
+    fn default() -> Self {
+        Self::with_size(100, 100)
     }
+}
 
+impl
+    MemoryStringCache<
+        SizedCache<String, Arc<UUIDText>>,
+        SizedCache<String, Arc<SharedCacheStrings>>,
+    >
+{
+    fn with_size(uuid_size: usize, shared_size: usize) -> Self {
+        Self {
+            uuidtext: Arc::new(RwLock::new(SizedCache::with_size(uuid_size))),
+            dsc: Arc::new(RwLock::new(SizedCache::with_size(shared_size))),
+        }
+    }
+}
+
+impl<U, D> StringCache for MemoryStringCache<U, D>
+where
+    U: Cached<String, Arc<UUIDText>> + Send + Sync,
+    D: Cached<String, Arc<SharedCacheStrings>> + Send + Sync,
+{
     /// Returns the cached [`UUIDText`] for `uuid`, loading it via `provider` if absent.
-    ///
-    /// `uuid2` is preserved from eviction alongside `uuid` so that a pair of UUIDs
-    /// referenced by the same log entry are not simultaneously evicted.
-    pub fn get_or_load_uuidtext(
+    fn get_or_load_uuidtext(
         &self,
         uuid: &str,
-        uuid2: &str,
         provider: &dyn FileProvider,
     ) -> Option<Arc<UUIDText>> {
         {
-            let map = self.uuidtext.read().unwrap();
-            if let Some(v) = map.get(uuid) {
+            let mut map = self.uuidtext.write().unwrap();
+            if let Some(v) = map.cache_get(uuid) {
                 return Some(Arc::clone(v));
             }
         }
@@ -68,19 +89,7 @@ impl StringCache {
         let value = Arc::new(provider.read_uuidtext(uuid).ok()?);
         let mut map = self.uuidtext.write().unwrap();
 
-        if map.len() >= UUIDTEXT_CACHE_MAX {
-            let to_evict: Vec<String> = map
-                .keys()
-                .filter(|k| k.as_str() != uuid && k.as_str() != uuid2)
-                .take(UUIDTEXT_EVICT_COUNT)
-                .cloned()
-                .collect();
-            for key in to_evict {
-                map.remove(&key);
-            }
-        }
-
-        map.insert(uuid.to_string(), Arc::clone(&value));
+        map.cache_set(uuid.to_string(), Arc::clone(&value));
         Some(value)
     }
 
@@ -88,15 +97,14 @@ impl StringCache {
     ///
     /// DSC files are large (~30 MB–150 MB each); at most [`DSC_CACHE_MAX`] are kept.
     /// `uuid2` is preserved from eviction alongside `uuid`.
-    pub fn get_or_load_dsc(
+    fn get_or_load_dsc(
         &self,
         uuid: &str,
-        uuid2: &str,
         provider: &dyn FileProvider,
     ) -> Option<Arc<SharedCacheStrings>> {
         {
-            let map = self.dsc.read().unwrap();
-            if let Some(v) = map.get(uuid) {
+            let mut map = self.dsc.write().unwrap();
+            if let Some(v) = map.cache_get(uuid) {
                 return Some(Arc::clone(v));
             }
         }
@@ -104,20 +112,7 @@ impl StringCache {
         let value = Arc::new(provider.read_dsc_uuid(uuid).ok()?);
         let mut map = self.dsc.write().unwrap();
 
-        while map.len() >= DSC_CACHE_MAX {
-            let key = map
-                .keys()
-                .find(|k| k.as_str() != uuid && k.as_str() != uuid2)
-                .cloned();
-            match key {
-                Some(k) => {
-                    map.remove(&k);
-                }
-                None => break,
-            }
-        }
-
-        map.insert(uuid.to_string(), Arc::clone(&value));
+        map.cache_set(uuid.to_string(), Arc::clone(&value));
         Some(value)
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -13,13 +13,14 @@ use crate::uuidtext::UUIDText;
 /// misses the cache takes an exclusive write lock only for the duration of the insert.
 ///
 /// # Multithreaded tracev3 processing
-/// ```rust,ignore
+/// ```rust,no_run
+/// use crate::macos_unifiedlogs::traits::FileProvider;
 /// use macos_unifiedlogs::cache::MemoryStringCache;
 /// use macos_unifiedlogs::filesystem::LogarchiveProvider;
 /// use macos_unifiedlogs::parser::{build_log, collect_timesync};
 /// use std::{path::PathBuf, sync::Arc};
 ///
-/// let provider = Arc::new(LogarchiveProvider::new(&path));
+/// let provider = Arc::new(LogarchiveProvider::new(&PathBuf::from("/tmp/log.logarchive")));
 /// let cache    = MemoryStringCache::default();
 /// let timesync = collect_timesync(provider.as_ref()).unwrap();
 ///

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,18 +1,39 @@
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
 use std::sync::{Arc, RwLock};
 
-use cached::{Cached, SizedCache};
-
 use crate::dsc::SharedCacheStrings;
-use crate::traits::{FileProvider, StringCache};
+use crate::traits::{Cache, FileProvider, StringCache};
 use crate::uuidtext::UUIDText;
 
 /// A thread-safe cache for [`UUIDText`] and [`SharedCacheStrings`] data shared during log parsing.
 ///
-/// Internally uses `Arc<RwLock<...>>` so that cloning produces a second handle to the same
-/// underlying maps; concurrent reads proceed without blocking each other, while a load that
-/// misses the cache takes an exclusive write lock only for the duration of the insert.
+/// The default implementation (`MemoryStringCache::default()`) uses unbounded `HashMap` maps
+/// wrapped in `Arc<RwLock<...>>`. Cloning produces a second handle to the same underlying
+/// maps — concurrent reads proceed without blocking each other, while a cache miss takes an
+/// exclusive write lock only for the duration of the insert.
 ///
-/// # Multithreaded tracev3 processing
+/// ## Bringing your own cache
+///
+/// The default implementation grows without bound. For long-running processes or large log
+/// collections, use [`MemoryStringCache::new`] to supply eviction-aware backends by implementing
+/// [`Cache`] for any type with interior mutability:
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use macos_unifiedlogs::{cache::MemoryStringCache, traits::Cache};
+/// use macos_unifiedlogs::{dsc::SharedCacheStrings, uuidtext::UUIDText};
+///
+/// struct BoundedCache(/* e.g. moka::sync::Cache<String, Arc<T>> */);
+///
+/// impl Cache<String, Arc<UUIDText>> for BoundedCache { /* ... */ }
+/// impl Cache<String, Arc<SharedCacheStrings>> for BoundedCache { /* ... */ }
+///
+/// let cache = MemoryStringCache::new(BoundedCache::new(), BoundedCache::new());
+/// ```
+///
+/// ## Multithreaded tracev3 processing
 /// ```rust,no_run
 /// use crate::macos_unifiedlogs::traits::FileProvider;
 /// use macos_unifiedlogs::cache::MemoryStringCache;
@@ -37,42 +58,79 @@ use crate::uuidtext::UUIDText;
 /// ```
 #[derive(Clone, Debug)]
 pub struct MemoryStringCache<
-    U: Cached<String, Arc<UUIDText>>,
-    D: Cached<String, Arc<SharedCacheStrings>>,
+    U: Cache<String, Arc<UUIDText>> + Send + Sync,
+    D: Cache<String, Arc<SharedCacheStrings>> + Send + Sync,
 > {
-    uuidtext: Arc<RwLock<U>>,
-    dsc: Arc<RwLock<D>>,
+    uuidtext: U,
+    dsc: D,
+}
+
+impl<U, D> MemoryStringCache<U, D>
+where
+    U: Cache<String, Arc<UUIDText>> + Send + Sync,
+    D: Cache<String, Arc<SharedCacheStrings>> + Send + Sync,
+{
+    pub fn new(uuidtext: U, dsc: D) -> Self {
+        Self { uuidtext, dsc }
+    }
 }
 
 impl Default
     for MemoryStringCache<
-        SizedCache<String, Arc<UUIDText>>,
-        SizedCache<String, Arc<SharedCacheStrings>>,
+        Arc<RwLock<HashMap<String, Arc<UUIDText>>>>,
+        Arc<RwLock<HashMap<String, Arc<SharedCacheStrings>>>>,
     >
 {
     fn default() -> Self {
-        Self::with_size(100, 100)
+        Self {
+            uuidtext: Arc::new(RwLock::new(HashMap::new())),
+            dsc: Arc::new(RwLock::new(HashMap::new())),
+        }
     }
 }
 
-impl
-    MemoryStringCache<
-        SizedCache<String, Arc<UUIDText>>,
-        SizedCache<String, Arc<SharedCacheStrings>>,
-    >
+impl<K, V, B> Cache<K, V> for RwLock<HashMap<K, V, B>>
+where
+    K: Eq + Hash,
+    V: Clone,
+    B: BuildHasher,
 {
-    fn with_size(uuid_size: usize, shared_size: usize) -> Self {
-        Self {
-            uuidtext: Arc::new(RwLock::new(SizedCache::with_size(uuid_size))),
-            dsc: Arc::new(RwLock::new(SizedCache::with_size(shared_size))),
-        }
+    fn get<Q>(&self, item: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        self.read().ok()?.get(item).cloned()
+    }
+
+    fn insert(&self, key: K, value: V) -> Option<V> {
+        self.write().ok()?.insert(key, value)
+    }
+}
+
+impl<K, V, B> Cache<K, V> for Arc<RwLock<HashMap<K, V, B>>>
+where
+    K: Eq + Hash,
+    V: Clone,
+    B: BuildHasher,
+{
+    fn get<Q>(&self, item: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        self.read().ok()?.get(item).cloned()
+    }
+
+    fn insert(&self, key: K, value: V) -> Option<V> {
+        self.write().ok()?.insert(key, value)
     }
 }
 
 impl<U, D> StringCache for MemoryStringCache<U, D>
 where
-    U: Cached<String, Arc<UUIDText>> + Send + Sync,
-    D: Cached<String, Arc<SharedCacheStrings>> + Send + Sync,
+    U: Cache<String, Arc<UUIDText>> + Send + Sync,
+    D: Cache<String, Arc<SharedCacheStrings>> + Send + Sync,
 {
     /// Returns the cached [`UUIDText`] for `uuid`, loading it via `provider` if absent.
     fn get_or_load_uuidtext(
@@ -81,39 +139,35 @@ where
         provider: &impl FileProvider,
     ) -> Option<Arc<UUIDText>> {
         {
-            let mut map = self.uuidtext.write().unwrap();
-            if let Some(v) = map.cache_get(uuid) {
-                return Some(Arc::clone(v));
+            if let Some(v) = self.uuidtext.get(uuid) {
+                return Some(Arc::clone(&v));
             }
         }
 
         let value = Arc::new(provider.read_uuidtext(uuid).ok()?);
-        let mut map = self.uuidtext.write().unwrap();
-
-        map.cache_set(uuid.to_string(), Arc::clone(&value));
+        self.uuidtext.insert(uuid.to_string(), Arc::clone(&value));
         Some(value)
     }
 
     /// Returns the cached [`SharedCacheStrings`] for `uuid`, loading it via `provider` if absent.
     ///
-    /// DSC files are large (~30 MB–150 MB each); at most [`DSC_CACHE_MAX`] are kept.
-    /// `uuid2` is preserved from eviction alongside `uuid`.
+    /// DSC files are large (~30 MB–150 MB each). The default `HashMap`-backed implementation
+    /// grows without bound; supply a bounded `D` via [`MemoryStringCache::new`] if eviction
+    /// is required.
     fn get_or_load_dsc(
         &self,
         uuid: &str,
         provider: &impl FileProvider,
     ) -> Option<Arc<SharedCacheStrings>> {
         {
-            let mut map = self.dsc.write().unwrap();
-            if let Some(v) = map.cache_get(uuid) {
-                return Some(Arc::clone(v));
+            if let Some(v) = self.dsc.get(uuid) {
+                return Some(Arc::clone(&v));
             }
         }
 
         let value = Arc::new(provider.read_dsc_uuid(uuid).ok()?);
-        let mut map = self.dsc.write().unwrap();
 
-        map.cache_set(uuid.to_string(), Arc::clone(&value));
+        self.dsc.insert(uuid.to_string(), Arc::clone(&value));
         Some(value)
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,123 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use crate::dsc::SharedCacheStrings;
+use crate::traits::FileProvider;
+use crate::uuidtext::UUIDText;
+
+const UUIDTEXT_CACHE_MAX: usize = 30;
+const UUIDTEXT_EVICT_COUNT: usize = 5;
+const DSC_CACHE_MAX: usize = 2;
+
+/// A thread-safe cache for [`UUIDText`] and [`SharedCacheStrings`] data shared during log parsing.
+///
+/// Internally uses `Arc<RwLock<...>>` so that cloning produces a second handle to the same
+/// underlying maps; concurrent reads proceed without blocking each other, while a load that
+/// misses the cache takes an exclusive write lock only for the duration of the insert.
+///
+/// # Multithreaded tracev3 processing
+/// ```rust,ignore
+/// use macos_unifiedlogs::cache::StringCache;
+/// use macos_unifiedlogs::filesystem::LogarchiveProvider;
+/// use macos_unifiedlogs::parser::{build_log, collect_timesync};
+/// use std::{path::PathBuf, sync::Arc};
+///
+/// let provider = Arc::new(LogarchiveProvider::new(&path));
+/// let cache    = StringCache::default();
+/// let timesync = collect_timesync(provider.as_ref()).unwrap();
+///
+/// std::thread::scope(|s| {
+///     for file in provider.tracev3_files() {
+///         let provider = Arc::clone(&provider);
+///         let cache    = cache.clone();       // cheap Arc clone
+///         let timesync = &timesync;
+///         s.spawn(move || {
+///             // parse + build_log with the shared cache
+///         });
+///     }
+/// });
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct StringCache {
+    uuidtext: Arc<RwLock<HashMap<String, Arc<UUIDText>>>>,
+    dsc: Arc<RwLock<HashMap<String, Arc<SharedCacheStrings>>>>,
+}
+
+impl StringCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the cached [`UUIDText`] for `uuid`, loading it via `provider` if absent.
+    ///
+    /// `uuid2` is preserved from eviction alongside `uuid` so that a pair of UUIDs
+    /// referenced by the same log entry are not simultaneously evicted.
+    pub fn get_or_load_uuidtext(
+        &self,
+        uuid: &str,
+        uuid2: &str,
+        provider: &dyn FileProvider,
+    ) -> Option<Arc<UUIDText>> {
+        {
+            let map = self.uuidtext.read().unwrap();
+            if let Some(v) = map.get(uuid) {
+                return Some(Arc::clone(v));
+            }
+        }
+
+        let value = Arc::new(provider.read_uuidtext(uuid).ok()?);
+        let mut map = self.uuidtext.write().unwrap();
+
+        if map.len() >= UUIDTEXT_CACHE_MAX {
+            let to_evict: Vec<String> = map
+                .keys()
+                .filter(|k| k.as_str() != uuid && k.as_str() != uuid2)
+                .take(UUIDTEXT_EVICT_COUNT)
+                .cloned()
+                .collect();
+            for key in to_evict {
+                map.remove(&key);
+            }
+        }
+
+        map.insert(uuid.to_string(), Arc::clone(&value));
+        Some(value)
+    }
+
+    /// Returns the cached [`SharedCacheStrings`] for `uuid`, loading it via `provider` if absent.
+    ///
+    /// DSC files are large (~30 MB–150 MB each); at most [`DSC_CACHE_MAX`] are kept.
+    /// `uuid2` is preserved from eviction alongside `uuid`.
+    pub fn get_or_load_dsc(
+        &self,
+        uuid: &str,
+        uuid2: &str,
+        provider: &dyn FileProvider,
+    ) -> Option<Arc<SharedCacheStrings>> {
+        {
+            let map = self.dsc.read().unwrap();
+            if let Some(v) = map.get(uuid) {
+                return Some(Arc::clone(v));
+            }
+        }
+
+        let value = Arc::new(provider.read_dsc_uuid(uuid).ok()?);
+        let mut map = self.dsc.write().unwrap();
+
+        while map.len() >= DSC_CACHE_MAX {
+            let key = map
+                .keys()
+                .find(|k| k.as_str() != uuid && k.as_str() != uuid2)
+                .cloned();
+            match key {
+                Some(k) => {
+                    map.remove(&k);
+                }
+                None => break,
+            }
+        }
+
+        map.insert(uuid.to_string(), Arc::clone(&value));
+        Some(value)
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,13 +14,13 @@ use crate::uuidtext::UUIDText;
 ///
 /// # Multithreaded tracev3 processing
 /// ```rust,ignore
-/// use macos_unifiedlogs::cache::StringCache;
+/// use macos_unifiedlogs::cache::MemoryStringCache;
 /// use macos_unifiedlogs::filesystem::LogarchiveProvider;
 /// use macos_unifiedlogs::parser::{build_log, collect_timesync};
 /// use std::{path::PathBuf, sync::Arc};
 ///
 /// let provider = Arc::new(LogarchiveProvider::new(&path));
-/// let cache    = StringCache::default();
+/// let cache    = MemoryStringCache::default();
 /// let timesync = collect_timesync(provider.as_ref()).unwrap();
 ///
 /// std::thread::scope(|s| {
@@ -77,7 +77,7 @@ where
     fn get_or_load_uuidtext(
         &self,
         uuid: &str,
-        provider: &dyn FileProvider,
+        provider: &impl FileProvider,
     ) -> Option<Arc<UUIDText>> {
         {
             let mut map = self.uuidtext.write().unwrap();
@@ -100,7 +100,7 @@ where
     fn get_or_load_dsc(
         &self,
         uuid: &str,
-        provider: &dyn FileProvider,
+        provider: &impl FileProvider,
     ) -> Option<Arc<SharedCacheStrings>> {
         {
             let mut map = self.dsc.write().unwrap();

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -9,8 +9,7 @@ use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
-use crate::cache::StringCache;
-use crate::traits::FileProvider;
+use crate::traits::{FileProvider, StringCache};
 use log::debug;
 use nom::number::complete::{le_u32, le_u64};
 
@@ -105,7 +104,7 @@ impl FirehoseActivity {
     pub(crate) fn get_firehose_activity_strings(
         firehose: &FirehoseActivity,
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -165,7 +164,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = crate::cache::StringCache::default();
+        let cache = crate::cache::MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000004.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -118,7 +118,13 @@ impl FirehoseActivity {
             supports_large_offset: true,
         };
 
-        MessageData::get_message(&firehose.firehose_formatters, provider, cache, &params, catalogs)
+        MessageData::get_message(
+            &firehose.firehose_formatters,
+            provider,
+            cache,
+            &params,
+            catalogs,
+        )
     }
 }
 

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -103,8 +103,8 @@ impl FirehoseActivity {
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose activity log entries (chunks)
     pub(crate) fn get_firehose_activity_strings(
         firehose: &FirehoseActivity,
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -9,6 +9,7 @@ use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
+use crate::cache::StringCache;
 use crate::traits::FileProvider;
 use log::debug;
 use nom::number::complete::{le_u32, le_u64};
@@ -101,14 +102,15 @@ impl FirehoseActivity {
     }
 
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose activity log entries (chunks)
-    pub(crate) fn get_firehose_activity_strings<'a>(
+    pub(crate) fn get_firehose_activity_strings(
         firehose: &FirehoseActivity,
-        provider: &'a mut dyn FileProvider,
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         let params = MessageParams {
             pc_id: firehose.pc_id,
             string_offset,
@@ -117,7 +119,7 @@ impl FirehoseActivity {
             supports_large_offset: true,
         };
 
-        MessageData::get_message(&firehose.firehose_formatters, provider, &params, catalogs)
+        MessageData::get_message(&firehose.firehose_formatters, provider, cache, &params, catalogs)
     }
 }
 
@@ -162,7 +164,8 @@ mod tests {
     fn test_get_firehose_activity_big_sur() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = crate::cache::StringCache::default();
 
         test_path.push("Persist/0000000000000004.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -176,7 +179,8 @@ mod tests {
                     if firehose.log_activity_type == activity_type {
                         let (_, message_data) = FirehoseActivity::get_firehose_activity_strings(
                             &firehose.firehose_activity,
-                            &mut provider,
+                            &provider,
+                            &cache,
                             u64::from(firehose.format_string_location),
                             preamble.first_number_proc_id,
                             preamble.second_number_proc_id,

--- a/src/chunks/firehose/message.rs
+++ b/src/chunks/firehose/message.rs
@@ -5,9 +5,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use crate::cache::StringCache;
 use crate::chunks::firehose::flags::FirehoseFormatters;
-use crate::traits::FileProvider;
+use crate::traits::{FileProvider, StringCache};
 use crate::util::extract_string;
 use crate::uuidtext::UUIDTextEntry;
 use crate::{catalog::CatalogChunk, util::u64_to_usize};
@@ -54,7 +53,7 @@ impl MessageData {
     pub(crate) fn get_message(
         formatters: &FirehoseFormatters,
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         params: &MessageParams,
         catalogs: &CatalogChunk,
     ) -> nom::IResult<&'static [u8], MessageData> {
@@ -148,7 +147,7 @@ impl MessageData {
     /// Shared strings contain library and message string
     fn extract_shared_strings(
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -163,7 +162,7 @@ impl MessageData {
 
         // Check if the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
-            && let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, &main_uuid, provider)
+            && let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, provider)
             && let Some(ranges) = shared_string.ranges.first()
         {
             let uuid_index = ranges.uuid_index as usize;
@@ -195,7 +194,7 @@ impl MessageData {
         }
 
         // Get shared strings collections
-        if let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, &main_uuid, provider) {
+        if let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, provider) {
             debug!("[macos-unifiedlogs] Associated dsc file with log entry: {dsc_uuid:?}");
 
             for ranges in &shared_string.ranges {
@@ -258,8 +257,11 @@ impl MessageData {
                     message_data.process_uuid = main_uuid;
 
                     // Extract image path from second UUIDtext file
-                    let (_, process_string) =
-                        MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
+                    let (_, process_string) = MessageData::get_uuid_image_path(
+                        &message_data.process_uuid,
+                        provider,
+                        cache,
+                    )?;
                     message_data.process = process_string;
                     return Ok((&[], message_data));
                 }
@@ -268,7 +270,7 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple reports as "~~> <Invalid shared cache code pointer offset>" or <Invalid shared cache format string offset>
-        if let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, &main_uuid, provider) {
+        if let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, provider) {
             // Still get the image path/library for the log entry
             if let Some(ranges) = shared_string.ranges.first() {
                 let uuid_index = ranges.uuid_index as usize;
@@ -310,7 +312,7 @@ impl MessageData {
     /// `UUIDText` file contains process and message string
     pub(crate) fn extract_format_strings(
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -329,8 +331,10 @@ impl MessageData {
 
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
-            && let Some(data) =
-                cache.get_or_load_uuidtext(&message_data.process_uuid, &message_data.process_uuid, provider)
+            && let Some(data) = cache.get_or_load_uuidtext(
+                &message_data.process_uuid,
+                provider,
+            )
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;
@@ -346,9 +350,10 @@ impl MessageData {
         }
 
         // Get the collection of parsed UUIDText files until matching UUID file is found
-        if let Some(data) =
-            cache.get_or_load_uuidtext(&message_data.process_uuid, &message_data.process_uuid, provider)
-        {
+        if let Some(data) = cache.get_or_load_uuidtext(
+            &message_data.process_uuid,
+            provider,
+        ) {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
@@ -389,9 +394,10 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) =
-            cache.get_or_load_uuidtext(&message_data.process_uuid, &message_data.process_uuid, provider)
-        {
+        if let Some(data) = cache.get_or_load_uuidtext(
+            &message_data.process_uuid,
+            provider,
+        ) {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -423,7 +429,7 @@ impl MessageData {
     /// `UUIDText` file contains process and message string
     fn extract_absolute_strings(
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         absolute_offset: u64,
         string_offset: u64,
         first_proc_id: u64,
@@ -469,8 +475,7 @@ impl MessageData {
 
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if ((original_offset & 0x80000000 != 0) || string_offset == absolute_offset)
-            && let Some(data) =
-                cache.get_or_load_uuidtext(&message_data.library_uuid, &message_data.process_uuid, provider)
+            && let Some(data) = cache.get_or_load_uuidtext(&message_data.library_uuid, provider)
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;
@@ -490,9 +495,10 @@ impl MessageData {
             return Ok((&[], message_data));
         }
 
-        if let Some(data) =
-            cache.get_or_load_uuidtext(&message_data.library_uuid, &message_data.process_uuid, provider)
-        {
+        if let Some(data) = cache.get_or_load_uuidtext(
+            &message_data.library_uuid,
+            provider,
+        ) {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
@@ -554,9 +560,10 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) =
-            cache.get_or_load_uuidtext(&message_data.library_uuid, &message_data.process_uuid, provider)
-        {
+        if let Some(data) = cache.get_or_load_uuidtext(
+            &message_data.library_uuid,
+            provider,
+        ) {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -593,7 +600,7 @@ impl MessageData {
     /// `UUIDText` files contains library and process and message string
     fn extract_alt_uuid_strings(
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         string_offset: u64,
         uuid: &str,
         first_proc_id: u64,
@@ -616,7 +623,7 @@ impl MessageData {
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
             && let Some(data) =
-                cache.get_or_load_uuidtext(uuid, &message_data.process_uuid, provider)
+                cache.get_or_load_uuidtext(uuid, provider)
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;
@@ -636,28 +643,27 @@ impl MessageData {
             return Ok((&[], message_data));
         }
 
-        if let Some(data) = cache.get_or_load_uuidtext(uuid, &message_data.process_uuid, provider)
-        {
+        if let Some(data) = cache.get_or_load_uuidtext(uuid, provider) {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
-                if entry.range_start_offset > string_offset as u32 {
+                if u64::from(entry.range_start_offset) > string_offset {
                     string_start += entry.entry_size;
                     continue;
                 }
-                let offset = string_offset as u32 - entry.range_start_offset;
+                let offset = string_offset - u64::from(entry.range_start_offset);
                 let strings = &data.footer_data;
                 let footer_data: &[u8] = strings;
 
                 // Check to make sure footer/string data is larger than the offset
                 // Or if the offset is greater than the entry size
                 // If offset greater than entry size then its not the correct UUIDText entry
-                if (footer_data.len() < offset as usize) || offset > entry.entry_size {
+                if ((footer_data.len() as u64) < offset) || offset > u64::from(entry.entry_size) {
                     string_start += entry.entry_size;
                     continue;
                 }
-                let (message_start, _) =
-                    take(offset + string_start)(footer_data).map_err(nom_err_to_static)?;
+                let (message_start, _) = take(offset + u64::from(string_start))(footer_data)
+                    .map_err(nom_err_to_static)?;
                 let (_, message_string) =
                     extract_string(message_start).map_err(nom_err_to_static)?;
 
@@ -678,8 +684,7 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) = cache.get_or_load_uuidtext(uuid, &message_data.process_uuid, provider)
-        {
+        if let Some(data) = cache.get_or_load_uuidtext(uuid, provider) {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -726,7 +731,7 @@ impl MessageData {
     fn get_uuid_image_path(
         main_uuid: &str,
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
     ) -> nom::IResult<&'static [u8], String> {
         // An UUID of all zeros is possilbe in the Catalog, if this happens there is no process path
         if main_uuid == "00000000000000000000000000000000" {
@@ -734,7 +739,7 @@ impl MessageData {
             return Ok((&[], String::new()));
         }
 
-        if let Some(data) = cache.get_or_load_uuidtext(main_uuid, main_uuid, provider) {
+        if let Some(data) = cache.get_or_load_uuidtext(main_uuid, provider) {
             return MessageData::uuidtext_image_path(&data.footer_data, &data.entry_descriptors);
         }
 
@@ -771,10 +776,8 @@ impl MessageData {
 #[cfg(test)]
 mod tests {
     use crate::{
-        cache::StringCache,
-        chunks::firehose::message::MessageData,
-        filesystem::LogarchiveProvider,
-        parser::parse_log,
+        cache::MemoryStringCache, chunks::firehose::message::MessageData,
+        filesystem::LogarchiveProvider, parser::parse_log,
     };
     use std::path::PathBuf;
 
@@ -783,7 +786,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -820,7 +823,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -854,7 +857,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -891,7 +894,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -926,7 +929,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
         let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
@@ -958,7 +961,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -999,7 +1002,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1035,7 +1038,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
 
@@ -1070,7 +1073,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1104,7 +1107,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1141,7 +1144,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1181,7 +1184,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000005.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1239,7 +1242,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
 
         let test_uuid = "B736DF1625F538248E9527A8CEC4991E";
         let (_, image_path) =

--- a/src/chunks/firehose/message.rs
+++ b/src/chunks/firehose/message.rs
@@ -52,8 +52,8 @@ impl MessageData {
     /// Get the base message for the log
     pub(crate) fn get_message(
         formatters: &FirehoseFormatters,
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         params: &MessageParams,
         catalogs: &CatalogChunk,
     ) -> nom::IResult<&'static [u8], MessageData> {
@@ -146,8 +146,8 @@ impl MessageData {
     /// Extract string from the Shared Strings Cache (dsc data)
     /// Shared strings contain library and message string
     fn extract_shared_strings(
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -311,8 +311,8 @@ impl MessageData {
     /// Extract strings from the `UUIDText` file associated with log entry
     /// `UUIDText` file contains process and message string
     pub(crate) fn extract_format_strings(
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -428,8 +428,8 @@ impl MessageData {
     /// Extract strings from the `UUIDText` file associated with log entry that have `absolute` flag set
     /// `UUIDText` file contains process and message string
     fn extract_absolute_strings(
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         absolute_offset: u64,
         string_offset: u64,
         first_proc_id: u64,
@@ -599,8 +599,8 @@ impl MessageData {
     /// Extract strings from an alt `UUIDText` file specified within the log entry that have `uuid_relative` flag set
     /// `UUIDText` files contains library and process and message string
     fn extract_alt_uuid_strings(
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         string_offset: u64,
         uuid: &str,
         first_proc_id: u64,
@@ -730,8 +730,8 @@ impl MessageData {
     /// Get the image path from provided `main_uuid` entry
     fn get_uuid_image_path(
         main_uuid: &str,
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
     ) -> nom::IResult<&'static [u8], String> {
         // An UUID of all zeros is possilbe in the Catalog, if this happens there is no process path
         if main_uuid == "00000000000000000000000000000000" {

--- a/src/chunks/firehose/message.rs
+++ b/src/chunks/firehose/message.rs
@@ -5,6 +5,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
+use crate::cache::StringCache;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::traits::FileProvider;
 use crate::util::extract_string;
@@ -30,16 +31,33 @@ pub(crate) struct MessageParams {
     pub(crate) supports_large_offset: bool,
 }
 
+/// Convert a nom error carrying any input lifetime to one carrying `&'static [u8]`.
+///
+/// All internal `extract_*` functions return `nom::IResult<&'static [u8], _>` because their
+/// leftover bytes are always `&[]` — they never actually consume from a caller-supplied slice.
+/// Intermediate nom operations borrow from locally-held `Arc<T>` values whose lifetime cannot
+/// be expressed in the return type, so errors are remapped here to drop the input reference.
+fn nom_err_to_static<I>(
+    e: nom::Err<nom::error::Error<I>>,
+) -> nom::Err<nom::error::Error<&'static [u8]>> {
+    match e {
+        nom::Err::Error(ne) => nom::Err::Error(nom::error::Error::new(&[], ne.code)),
+        nom::Err::Failure(ne) => nom::Err::Failure(nom::error::Error::new(&[], ne.code)),
+        nom::Err::Incomplete(n) => nom::Err::Incomplete(n),
+    }
+}
+
 // Functions to help extract base format string based on flags associated with log entries
 // Ex: "%s start"
 impl MessageData {
     /// Get the base message for the log
-    pub(crate) fn get_message<'a>(
+    pub(crate) fn get_message(
         formatters: &FirehoseFormatters,
-        provider: &'a mut dyn FileProvider,
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         params: &MessageParams,
         catalogs: &CatalogChunk,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         let string_offset = params.string_offset;
         let pc_id = params.pc_id;
         let shared_cache_string = formatters.shared_cache
@@ -69,6 +87,7 @@ impl MessageData {
 
                 return MessageData::extract_shared_strings(
                     provider,
+                    cache,
                     real_offset,
                     params.first_proc_id,
                     params.second_proc_id,
@@ -78,6 +97,7 @@ impl MessageData {
             }
             return MessageData::extract_shared_strings(
                 provider,
+                cache,
                 string_offset,
                 params.first_proc_id,
                 params.second_proc_id,
@@ -92,6 +112,7 @@ impl MessageData {
 
             return MessageData::extract_absolute_strings(
                 provider,
+                cache,
                 offset,
                 string_offset,
                 params.first_proc_id,
@@ -103,6 +124,7 @@ impl MessageData {
         if !formatters.uuid_relative.is_empty() {
             return MessageData::extract_alt_uuid_strings(
                 provider,
+                cache,
                 string_offset,
                 &formatters.uuid_relative,
                 params.first_proc_id,
@@ -113,6 +135,7 @@ impl MessageData {
         }
         MessageData::extract_format_strings(
             provider,
+            cache,
             string_offset,
             params.first_proc_id,
             params.second_proc_id,
@@ -123,34 +146,24 @@ impl MessageData {
 
     /// Extract string from the Shared Strings Cache (dsc data)
     /// Shared strings contain library and message string
-    fn extract_shared_strings<'a>(
-        provider: &'a mut dyn FileProvider,
+    fn extract_shared_strings(
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
         original_offset: u64,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         debug!("[macos-unifiedlogs] Extracting format string from shared cache file (dsc)");
         let mut message_data = MessageData::default();
         // Get shared string file (DSC) associated with log entry from Catalog
         let (dsc_uuid, main_uuid) =
             MessageData::get_catalog_dsc(catalogs, first_proc_id, second_proc_id);
 
-        // Ensure our cache is up to date
-        // We need dsc_uuid and main_uuid in order to obtain all the data
-        if provider.cached_dsc(&dsc_uuid).is_none() {
-            // Include main_uuid just incase
-            provider.update_dsc(&dsc_uuid, &main_uuid);
-        }
-        if provider.cached_uuidtext(&main_uuid).is_none() {
-            // `update_uuid` only reads UUIDText files. dsc_uuid is not applicable
-            provider.update_uuid(&main_uuid, &main_uuid);
-        }
-
         // Check if the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
-            && let Some(shared_string) = provider.cached_dsc(&dsc_uuid)
+            && let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, &main_uuid, provider)
             && let Some(ranges) = shared_string.ranges.first()
         {
             let uuid_index = ranges.uuid_index as usize;
@@ -175,14 +188,14 @@ impl MessageData {
 
             // Extract image path from second UUIDtext file
             let (_, process_string) =
-                MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
             message_data.process = process_string;
 
             return Ok((&[], message_data));
         }
 
         // Get shared strings collections
-        if let Some(shared_string) = provider.cached_dsc(&dsc_uuid) {
+        if let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, &main_uuid, provider) {
             debug!("[macos-unifiedlogs] Associated dsc file with log entry: {dsc_uuid:?}");
 
             for ranges in &shared_string.ranges {
@@ -219,8 +232,10 @@ impl MessageData {
                             )));
                         }
                     };
-                    let (message_start, _) = take(offset)(string_data)?;
-                    let (_, message_string) = extract_string(message_start)?;
+                    let (message_start, _) =
+                        take(offset)(string_data).map_err(nom_err_to_static)?;
+                    let (_, message_string) =
+                        extract_string(message_start).map_err(nom_err_to_static)?;
                     message_data.format_string = message_string;
 
                     let uuid_index = ranges.uuid_index as usize;
@@ -244,7 +259,7 @@ impl MessageData {
 
                     // Extract image path from second UUIDtext file
                     let (_, process_string) =
-                        MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                        MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
                     message_data.process = process_string;
                     return Ok((&[], message_data));
                 }
@@ -253,7 +268,7 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple reports as "~~> <Invalid shared cache code pointer offset>" or <Invalid shared cache format string offset>
-        if let Some(shared_string) = provider.cached_dsc(&dsc_uuid) {
+        if let Some(shared_string) = cache.get_or_load_dsc(&dsc_uuid, &main_uuid, provider) {
             // Still get the image path/library for the log entry
             if let Some(ranges) = shared_string.ranges.first() {
                 let uuid_index = ranges.uuid_index as usize;
@@ -278,7 +293,7 @@ impl MessageData {
 
                 // Extract image path from second UUIDtext file
                 let (_, process_string) =
-                    MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                    MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
                 message_data.process = process_string;
 
                 return Ok((&[], message_data));
@@ -293,14 +308,15 @@ impl MessageData {
 
     /// Extract strings from the `UUIDText` file associated with log entry
     /// `UUIDText` file contains process and message string
-    pub(crate) fn extract_format_strings<'a>(
-        provider: &'a mut dyn FileProvider,
+    pub(crate) fn extract_format_strings(
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
         original_offset: u64,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         debug!("[macos-unifiedlogs] Extracting format string from UUID file");
         let (_, main_uuid) = MessageData::get_catalog_dsc(catalogs, first_proc_id, second_proc_id);
 
@@ -311,18 +327,10 @@ impl MessageData {
             ..Default::default()
         };
 
-        // Ensure our cache is up to date
-        // We do not have any dsc UUID files. We are just using UUIDText file(s)
-        if provider
-            .cached_uuidtext(&message_data.process_uuid)
-            .is_none()
-        {
-            provider.update_uuid(&message_data.process_uuid, &message_data.process_uuid);
-        }
-
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
-            && let Some(data) = provider.cached_uuidtext(&message_data.process_uuid)
+            && let Some(data) =
+                cache.get_or_load_uuidtext(&message_data.process_uuid, &message_data.process_uuid, provider)
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;
@@ -338,7 +346,9 @@ impl MessageData {
         }
 
         // Get the collection of parsed UUIDText files until matching UUID file is found
-        if let Some(data) = provider.cached_uuidtext(&message_data.process_uuid) {
+        if let Some(data) =
+            cache.get_or_load_uuidtext(&message_data.process_uuid, &message_data.process_uuid, provider)
+        {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
@@ -360,8 +370,10 @@ impl MessageData {
                     continue;
                 }
 
-                let (message_start, _) = take(offset + string_start)(footer_data)?;
-                let (_, message_string) = extract_string(message_start)?;
+                let (message_start, _) =
+                    take(offset + string_start)(footer_data).map_err(nom_err_to_static)?;
+                let (_, message_string) =
+                    extract_string(message_start).map_err(nom_err_to_static)?;
 
                 let (_, process_string) =
                     MessageData::uuidtext_image_path(footer_data, &data.entry_descriptors)?;
@@ -377,7 +389,9 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) = provider.cached_uuidtext(&message_data.process_uuid) {
+        if let Some(data) =
+            cache.get_or_load_uuidtext(&message_data.process_uuid, &message_data.process_uuid, provider)
+        {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -407,15 +421,16 @@ impl MessageData {
 
     /// Extract strings from the `UUIDText` file associated with log entry that have `absolute` flag set
     /// `UUIDText` file contains process and message string
-    fn extract_absolute_strings<'a>(
-        provider: &'a mut dyn FileProvider,
+    fn extract_absolute_strings(
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         absolute_offset: u64,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
         original_offset: u64,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         debug!(
             "[macos-unifiedlogs] Extracting format string from UUID file for log entry with Absolute flag"
         );
@@ -452,24 +467,10 @@ impl MessageData {
             process_uuid: main_uuid,
         };
 
-        // Ensure our cache is up to date
-        // We do not have any dsc UUID files. We are just using UUIDText file(s)
-        if provider
-            .cached_uuidtext(&message_data.process_uuid)
-            .is_none()
-        {
-            provider.update_uuid(&message_data.process_uuid, &message_data.library_uuid);
-        }
-        // Verify library_uuid is cached
-        if provider
-            .cached_uuidtext(&message_data.library_uuid)
-            .is_none()
-        {
-            provider.update_uuid(&message_data.library_uuid, &message_data.process_uuid);
-        }
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if ((original_offset & 0x80000000 != 0) || string_offset == absolute_offset)
-            && let Some(data) = provider.cached_uuidtext(&message_data.library_uuid)
+            && let Some(data) =
+                cache.get_or_load_uuidtext(&message_data.library_uuid, &message_data.process_uuid, provider)
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;
@@ -482,14 +483,16 @@ impl MessageData {
 
             // Extract image path from second UUIDtext file
             let (_, process_string) =
-                MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
             message_data.process = process_string;
             message_data.format_string = String::from("%s");
 
             return Ok((&[], message_data));
         }
 
-        if let Some(data) = provider.cached_uuidtext(&message_data.library_uuid) {
+        if let Some(data) =
+            cache.get_or_load_uuidtext(&message_data.library_uuid, &message_data.process_uuid, provider)
+        {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
@@ -530,8 +533,10 @@ impl MessageData {
                         )));
                     }
                 };
-                let (message_start, _) = take(offset + string_start)(footer_data)?;
-                let (_, message_string) = extract_string(message_start)?;
+                let (message_start, _) =
+                    take(offset + string_start)(footer_data).map_err(nom_err_to_static)?;
+                let (_, message_string) =
+                    extract_string(message_start).map_err(nom_err_to_static)?;
 
                 // Extract image path from current UUIDtext file
                 let (_, library_string) =
@@ -541,7 +546,7 @@ impl MessageData {
 
                 // Extract image path from second UUIDtext file
                 let (_, process_string) =
-                    MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                    MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
                 message_data.process = process_string;
                 return Ok((&[], message_data));
             }
@@ -549,7 +554,9 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) = provider.cached_uuidtext(&message_data.library_uuid) {
+        if let Some(data) =
+            cache.get_or_load_uuidtext(&message_data.library_uuid, &message_data.process_uuid, provider)
+        {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -565,7 +572,7 @@ impl MessageData {
 
             // Extract image path from second UUIDtext file
             let (_, process_string) =
-                MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
             message_data.process = process_string;
 
             return Ok((&[], message_data));
@@ -584,15 +591,16 @@ impl MessageData {
 
     /// Extract strings from an alt `UUIDText` file specified within the log entry that have `uuid_relative` flag set
     /// `UUIDText` files contains library and process and message string
-    fn extract_alt_uuid_strings<'a>(
-        provider: &'a mut dyn FileProvider,
+    fn extract_alt_uuid_strings(
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         string_offset: u64,
         uuid: &str,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
         original_offset: u64,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         debug!("[macos-unifiedlogs] Extracting format string from alt uuid");
         // Log entries with uuid_relative flags set have the UUID in the log itself. They do not use the dsc UUID files
         let (_, main_uuid) = MessageData::get_catalog_dsc(catalogs, first_proc_id, second_proc_id);
@@ -605,24 +613,10 @@ impl MessageData {
             process_uuid: main_uuid,
         };
 
-        // Ensure our cache is up to date
-        // We do not have any dsc UUID files. We are just using UUIDText file(s)
-        if provider
-            .cached_uuidtext(&message_data.library_uuid)
-            .is_none()
-        {
-            provider.update_uuid(&message_data.library_uuid, &message_data.process_uuid);
-        }
-        // Verify process_uuid is cached
-        if provider
-            .cached_uuidtext(&message_data.process_uuid)
-            .is_none()
-        {
-            provider.update_uuid(&message_data.process_uuid, &message_data.library_uuid);
-        }
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
-            && let Some(data) = provider.cached_uuidtext(uuid)
+            && let Some(data) =
+                cache.get_or_load_uuidtext(uuid, &message_data.process_uuid, provider)
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;
@@ -635,14 +629,15 @@ impl MessageData {
 
             // Extract image path from second UUIDtext file
             let (_, process_string) =
-                MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
             message_data.process = process_string;
             message_data.format_string = String::from("%s");
 
             return Ok((&[], message_data));
         }
 
-        if let Some(data) = provider.cached_uuidtext(uuid) {
+        if let Some(data) = cache.get_or_load_uuidtext(uuid, &message_data.process_uuid, provider)
+        {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
@@ -661,8 +656,10 @@ impl MessageData {
                     string_start += entry.entry_size;
                     continue;
                 }
-                let (message_start, _) = take(offset + string_start)(footer_data)?;
-                let (_, message_string) = extract_string(message_start)?;
+                let (message_start, _) =
+                    take(offset + string_start)(footer_data).map_err(nom_err_to_static)?;
+                let (_, message_string) =
+                    extract_string(message_start).map_err(nom_err_to_static)?;
 
                 // Extract image path from current UUIDtext file
                 let (_, library_string) =
@@ -670,7 +667,7 @@ impl MessageData {
 
                 // Extract image path from second UUIDtext file
                 let (_, process_string) =
-                    MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                    MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
                 message_data.process = process_string;
 
                 message_data.format_string = message_string;
@@ -681,7 +678,8 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) = provider.cached_uuidtext(uuid) {
+        if let Some(data) = cache.get_or_load_uuidtext(uuid, &message_data.process_uuid, provider)
+        {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -695,7 +693,7 @@ impl MessageData {
 
             // Extract image path from second UUIDtext file
             let (_, process_string) =
-                MessageData::get_uuid_image_path(&message_data.process_uuid, provider)?;
+                MessageData::get_uuid_image_path(&message_data.process_uuid, provider, cache)?;
             message_data.process = process_string;
 
             return Ok((&[], message_data));
@@ -710,31 +708,33 @@ impl MessageData {
     }
 
     /// Get the image path at the end of the `UUIDText` file
-    fn uuidtext_image_path<'a>(
-        data: &'a [u8],
+    fn uuidtext_image_path(
+        data: &[u8],
         entries: &[UUIDTextEntry],
-    ) -> nom::IResult<&'a [u8], String> {
+    ) -> nom::IResult<&'static [u8], String> {
         // Add up all entry range offset sizes to get image library offset
-        let mut image_library_offest: u32 = 0;
+        let mut image_library_offset: u32 = 0;
         for entry in entries {
-            image_library_offest += entry.entry_size;
+            image_library_offset += entry.entry_size;
         }
-        let (library_start, _) = take(image_library_offest)(data)?;
-        extract_string(library_start)
+        let (library_start, _) = take(image_library_offset)(data).map_err(nom_err_to_static)?;
+        let (_, result) = extract_string(library_start).map_err(nom_err_to_static)?;
+        Ok((&[], result))
     }
 
     /// Get the image path from provided `main_uuid` entry
-    fn get_uuid_image_path<'a>(
+    fn get_uuid_image_path(
         main_uuid: &str,
-        provider: &'a dyn FileProvider,
-    ) -> nom::IResult<&'a [u8], String> {
+        provider: &dyn FileProvider,
+        cache: &StringCache,
+    ) -> nom::IResult<&'static [u8], String> {
         // An UUID of all zeros is possilbe in the Catalog, if this happens there is no process path
         if main_uuid == "00000000000000000000000000000000" {
             info!("[macos-unifiedlogs] Got UUID of all zeros fom Catalog");
             return Ok((&[], String::new()));
         }
 
-        if let Some(data) = provider.cached_uuidtext(main_uuid) {
+        if let Some(data) = cache.get_or_load_uuidtext(main_uuid, main_uuid, provider) {
             return MessageData::uuidtext_image_path(&data.footer_data, &data.entry_descriptors);
         }
 
@@ -771,8 +771,10 @@ impl MessageData {
 #[cfg(test)]
 mod tests {
     use crate::{
-        chunks::firehose::message::MessageData, filesystem::LogarchiveProvider, parser::parse_log,
-        traits::FileProvider,
+        cache::StringCache,
+        chunks::firehose::message::MessageData,
+        filesystem::LogarchiveProvider,
+        parser::parse_log,
     };
     use std::path::PathBuf;
 
@@ -780,7 +782,8 @@ mod tests {
     fn test_extract_shared_strings_nonactivity() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -791,7 +794,8 @@ mod tests {
         let test_second_proc_id = 188;
 
         let (_, results) = MessageData::extract_shared_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_offset,
             test_first_proc_id,
             test_second_proc_id,
@@ -815,7 +819,8 @@ mod tests {
     fn test_extract_shared_strings_nonactivity_bad_offset() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -826,7 +831,8 @@ mod tests {
         let test_second_proc_id = 188;
 
         let (_, results) = MessageData::extract_shared_strings(
-            &mut provider,
+            &provider,
+            &cache,
             bad_offset,
             test_first_proc_id,
             test_second_proc_id,
@@ -847,7 +853,8 @@ mod tests {
     fn test_extract_shared_strings_nonactivity_dynamic() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -857,7 +864,8 @@ mod tests {
         let test_first_proc_id = 32;
         let test_second_proc_id = 424;
         let (_, results) = MessageData::extract_shared_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_offset,
             test_first_proc_id,
             test_second_proc_id,
@@ -882,7 +890,8 @@ mod tests {
     fn test_extract_format_strings_nonactivity() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -892,7 +901,8 @@ mod tests {
         let test_first_proc_id = 45;
         let test_second_proc_id = 188;
         let (_, results) = MessageData::extract_format_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_offset,
             test_first_proc_id,
             test_second_proc_id,
@@ -915,7 +925,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
         let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
@@ -924,7 +935,8 @@ mod tests {
         let test_first_proc_id = 45;
         let test_second_proc_id = 188;
         let (_, results) = MessageData::extract_format_strings(
-            &mut provider,
+            &provider,
+            &cache,
             bad_offset,
             test_first_proc_id,
             test_second_proc_id,
@@ -945,7 +957,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -955,7 +968,8 @@ mod tests {
         let test_first_proc_id = 38;
         let test_second_proc_id = 317;
         let (_, results) = MessageData::extract_format_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_offset,
             test_first_proc_id,
             test_second_proc_id,
@@ -984,7 +998,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -994,7 +1009,8 @@ mod tests {
         let test_first_proc_id = 38;
         let test_second_proc_id = 317;
         let (_, results) = MessageData::extract_format_strings(
-            &mut provider,
+            &provider,
+            &cache,
             bad_offset,
             test_first_proc_id,
             test_second_proc_id,
@@ -1018,7 +1034,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
 
@@ -1030,7 +1047,8 @@ mod tests {
         let test_first_proc_id = 0;
         let test_second_proc_id = 0;
         let (_, results) = MessageData::extract_absolute_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_absolute_offset,
             test_offset,
             test_first_proc_id,
@@ -1051,7 +1069,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1062,7 +1081,8 @@ mod tests {
         let test_first_proc_id = 0;
         let test_second_proc_id = 0;
         let (_, results) = MessageData::extract_absolute_strings(
-            &mut provider,
+            &provider,
+            &cache,
             bad_offset,
             test_offset,
             test_first_proc_id,
@@ -1083,7 +1103,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1096,7 +1117,8 @@ mod tests {
         let test_first_proc_id = 0;
         let test_second_proc_id = 0;
         let (_, results) = MessageData::extract_absolute_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_absolute_offset,
             test_offset,
             test_first_proc_id,
@@ -1118,7 +1140,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1131,7 +1154,8 @@ mod tests {
         let test_first_proc_id = 0;
         let test_second_proc_id = 0;
         let (_, results) = MessageData::extract_absolute_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_absolute_offset,
             bad_offset,
             test_first_proc_id,
@@ -1156,7 +1180,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         test_path.push("Persist/0000000000000005.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -1168,7 +1193,8 @@ mod tests {
         let test_offset = 221408;
         let test_uuid = "C275D5EEBAD43A86B74F16F3E62BF57D";
         let (_, results) = MessageData::extract_alt_uuid_strings(
-            &mut provider,
+            &provider,
+            &cache,
             test_offset,
             test_uuid,
             first_proc_id,
@@ -1212,12 +1238,12 @@ mod tests {
     fn test_get_uuid_image_path() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
 
         let test_uuid = "B736DF1625F538248E9527A8CEC4991E";
-        provider.update_uuid(test_uuid, test_uuid);
-
-        let (_, image_path) = MessageData::get_uuid_image_path(test_uuid, &provider).unwrap();
+        let (_, image_path) =
+            MessageData::get_uuid_image_path(test_uuid, &provider, &cache).unwrap();
 
         assert_eq!(image_path, "/usr/libexec/opendirectoryd");
     }

--- a/src/chunks/firehose/message.rs
+++ b/src/chunks/firehose/message.rs
@@ -331,10 +331,7 @@ impl MessageData {
 
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
-            && let Some(data) = cache.get_or_load_uuidtext(
-                &message_data.process_uuid,
-                provider,
-            )
+            && let Some(data) = cache.get_or_load_uuidtext(&message_data.process_uuid, provider)
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;
@@ -350,10 +347,7 @@ impl MessageData {
         }
 
         // Get the collection of parsed UUIDText files until matching UUID file is found
-        if let Some(data) = cache.get_or_load_uuidtext(
-            &message_data.process_uuid,
-            provider,
-        ) {
+        if let Some(data) = cache.get_or_load_uuidtext(&message_data.process_uuid, provider) {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
@@ -394,10 +388,7 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) = cache.get_or_load_uuidtext(
-            &message_data.process_uuid,
-            provider,
-        ) {
+        if let Some(data) = cache.get_or_load_uuidtext(&message_data.process_uuid, provider) {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -495,10 +486,7 @@ impl MessageData {
             return Ok((&[], message_data));
         }
 
-        if let Some(data) = cache.get_or_load_uuidtext(
-            &message_data.library_uuid,
-            provider,
-        ) {
+        if let Some(data) = cache.get_or_load_uuidtext(&message_data.library_uuid, provider) {
             let mut string_start = 0;
             for entry in &data.entry_descriptors {
                 // Identify start of string formatter offset
@@ -560,10 +548,7 @@ impl MessageData {
 
         // There is a chance the log entry does not have a valid offset
         // Apple labels as "error: ~~> Invalid bounds 4334340 for E502E11E-518F-38A7-9F0B-E129168338E7"
-        if let Some(data) = cache.get_or_load_uuidtext(
-            &message_data.library_uuid,
-            provider,
-        ) {
+        if let Some(data) = cache.get_or_load_uuidtext(&message_data.library_uuid, provider) {
             // Footer data is a collection of strings that ends with the image process associated with the strings
             let strings = &data.footer_data;
             let footer_data: &[u8] = strings;
@@ -622,8 +607,7 @@ impl MessageData {
 
         // If most significant bit is set, the string offset is "dynamic" (the formatter is "%s")
         if original_offset & 0x80000000 != 0
-            && let Some(data) =
-                cache.get_or_load_uuidtext(uuid, provider)
+            && let Some(data) = cache.get_or_load_uuidtext(uuid, provider)
         {
             // Footer data is a collection of strings that ends with the image path/library associated with strings
             let strings = &data.footer_data;

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -9,6 +9,7 @@ use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
+use crate::cache::StringCache;
 use crate::traits::FileProvider;
 use log::debug;
 use nom::number::complete::{le_u8, le_u16, le_u32};
@@ -108,14 +109,15 @@ impl FirehoseNonActivity {
     }
 
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose non-activity log entries (chunks)
-    pub(crate) fn get_firehose_nonactivity_strings<'a>(
+    pub(crate) fn get_firehose_nonactivity_strings(
         firehose: &FirehoseNonActivity,
-        provider: &'a mut dyn FileProvider,
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         let params = MessageParams {
             pc_id: firehose.pc_id,
             string_offset,
@@ -124,7 +126,7 @@ impl FirehoseNonActivity {
             supports_large_offset: false,
         };
 
-        MessageData::get_message(&firehose.firehose_formatters, provider, &params, catalogs)
+        MessageData::get_message(&firehose.firehose_formatters, provider, cache, &params, catalogs)
     }
 }
 
@@ -176,7 +178,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = crate::cache::StringCache::default();
         test_path.push("Persist/0000000000000004.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
         let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
@@ -190,7 +193,8 @@ mod tests {
                         let (_, message_data) =
                             FirehoseNonActivity::get_firehose_nonactivity_strings(
                                 &firehose.firehose_non_activity,
-                                &mut provider,
+                                &provider,
+                                &cache,
                                 u64::from(firehose.format_string_location),
                                 preamble.first_number_proc_id,
                                 preamble.second_number_proc_id,

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -9,8 +9,7 @@ use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
-use crate::cache::StringCache;
-use crate::traits::FileProvider;
+use crate::traits::{FileProvider, StringCache};
 use log::debug;
 use nom::number::complete::{le_u8, le_u16, le_u32};
 
@@ -112,7 +111,7 @@ impl FirehoseNonActivity {
     pub(crate) fn get_firehose_nonactivity_strings(
         firehose: &FirehoseNonActivity,
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -179,7 +178,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = crate::cache::StringCache::default();
+        let cache = crate::cache::MemoryStringCache::default();
         test_path.push("Persist/0000000000000004.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
         let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -110,8 +110,8 @@ impl FirehoseNonActivity {
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose non-activity log entries (chunks)
     pub(crate) fn get_firehose_nonactivity_strings(
         firehose: &FirehoseNonActivity,
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -125,7 +125,13 @@ impl FirehoseNonActivity {
             supports_large_offset: false,
         };
 
-        MessageData::get_message(&firehose.firehose_formatters, provider, cache, &params, catalogs)
+        MessageData::get_message(
+            &firehose.firehose_formatters,
+            provider,
+            cache,
+            &params,
+            catalogs,
+        )
     }
 }
 

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -9,6 +9,7 @@ use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
+use crate::cache::StringCache;
 use crate::traits::FileProvider;
 use log::debug;
 use nom::number::complete::{le_u8, le_u16, le_u32, le_u64};
@@ -128,14 +129,15 @@ impl FirehoseSignpost {
     }
 
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose signpost log entries (chunks)
-    pub(crate) fn get_firehose_signpost<'a>(
+    pub(crate) fn get_firehose_signpost(
         firehose: &FirehoseSignpost,
-        provider: &'a mut dyn FileProvider,
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         let params = MessageParams {
             pc_id: firehose.pc_id,
             string_offset,
@@ -144,7 +146,7 @@ impl FirehoseSignpost {
             supports_large_offset: true,
         };
 
-        MessageData::get_message(&firehose.firehose_formatters, provider, &params, catalogs)
+        MessageData::get_message(&firehose.firehose_formatters, provider, cache, &params, catalogs)
     }
 }
 
@@ -186,7 +188,8 @@ mod tests {
     fn test_get_firehose_signpost_big_sur() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = crate::cache::StringCache::default();
 
         test_path.push("Signpost/0000000000000001.tracev3");
 
@@ -201,7 +204,8 @@ mod tests {
                     if firehose.log_activity_type == activity_type {
                         let (_, message_data) = FirehoseSignpost::get_firehose_signpost(
                             &firehose.firehose_signpost,
-                            &mut provider,
+                            &provider,
+                            &cache,
                             u64::from(firehose.format_string_location),
                             preamble.first_number_proc_id,
                             preamble.second_number_proc_id,

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -130,8 +130,8 @@ impl FirehoseSignpost {
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose signpost log entries (chunks)
     pub(crate) fn get_firehose_signpost(
         firehose: &FirehoseSignpost,
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -145,7 +145,13 @@ impl FirehoseSignpost {
             supports_large_offset: true,
         };
 
-        MessageData::get_message(&firehose.firehose_formatters, provider, cache, &params, catalogs)
+        MessageData::get_message(
+            &firehose.firehose_formatters,
+            provider,
+            cache,
+            &params,
+            catalogs,
+        )
     }
 }
 

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -9,8 +9,7 @@ use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::MessageFlags;
 use crate::chunks::firehose::flags::FirehoseFormatters;
 use crate::chunks::firehose::message::{MessageData, MessageParams};
-use crate::cache::StringCache;
-use crate::traits::FileProvider;
+use crate::traits::{FileProvider, StringCache};
 use log::debug;
 use nom::number::complete::{le_u8, le_u16, le_u32, le_u64};
 
@@ -132,7 +131,7 @@ impl FirehoseSignpost {
     pub(crate) fn get_firehose_signpost(
         firehose: &FirehoseSignpost,
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -189,7 +188,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = crate::cache::StringCache::default();
+        let cache = crate::cache::MemoryStringCache::default();
 
         test_path.push("Signpost/0000000000000001.tracev3");
 

--- a/src/chunks/firehose/trace.rs
+++ b/src/chunks/firehose/trace.rs
@@ -125,8 +125,8 @@ impl FirehoseTrace {
 
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose trace log entries (chunks)
     pub(crate) fn get_firehose_trace_strings(
-        provider: &dyn FileProvider,
-        cache: &dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,

--- a/src/chunks/firehose/trace.rs
+++ b/src/chunks/firehose/trace.rs
@@ -8,6 +8,7 @@
 use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::{FirehoseItemData, FirehoseItemType};
 use crate::chunks::firehose::message::MessageData;
+use crate::cache::StringCache;
 use crate::traits::FileProvider;
 use log::{error, warn};
 use nom::bytes::complete::take;
@@ -124,16 +125,18 @@ impl FirehoseTrace {
     }
 
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose trace log entries (chunks)
-    pub(crate) fn get_firehose_trace_strings<'a>(
-        provider: &'a mut dyn FileProvider,
+    pub(crate) fn get_firehose_trace_strings(
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
         catalogs: &CatalogChunk,
-    ) -> nom::IResult<&'a [u8], MessageData> {
+    ) -> nom::IResult<&'static [u8], MessageData> {
         // Only main_exe flag has been seen for format strings
         MessageData::extract_format_strings(
             provider,
+            cache,
             string_offset,
             first_proc_id,
             second_proc_id,
@@ -193,7 +196,8 @@ mod tests {
     fn test_get_firehose_trace_strings() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = crate::cache::StringCache::default();
 
         test_path.push("logdata.LiveData.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -207,7 +211,8 @@ mod tests {
                 for firehose in preamble.public_data {
                     if firehose.log_activity_type == activity_type {
                         let (_, message_data) = FirehoseTrace::get_firehose_trace_strings(
-                            &mut provider,
+                            &provider,
+                            &cache,
                             u64::from(firehose.format_string_location),
                             preamble.first_number_proc_id,
                             preamble.second_number_proc_id,

--- a/src/chunks/firehose/trace.rs
+++ b/src/chunks/firehose/trace.rs
@@ -8,8 +8,7 @@
 use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::firehose_log::{FirehoseItemData, FirehoseItemType};
 use crate::chunks::firehose::message::MessageData;
-use crate::cache::StringCache;
-use crate::traits::FileProvider;
+use crate::traits::{FileProvider, StringCache};
 use log::{error, warn};
 use nom::bytes::complete::take;
 use nom::number::complete::{be_u8, be_u16, be_u32, be_u64, le_u8, le_u32};
@@ -127,7 +126,7 @@ impl FirehoseTrace {
     /// Get base log message string formatter from shared cache strings (dsc) or UUID text file for firehose trace log entries (chunks)
     pub(crate) fn get_firehose_trace_strings(
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: &dyn StringCache,
         string_offset: u64,
         first_proc_id: u64,
         second_proc_id: u32,
@@ -197,7 +196,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = crate::cache::StringCache::default();
+        let cache = crate::cache::MemoryStringCache::default();
 
         test_path.push("logdata.LiveData.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -109,11 +109,9 @@ impl FileProvider for LiveSystemProvider {
             WalkDir::new(path)
                 .sort_by(|a, b| a.file_name().cmp(b.file_name()))
                 .into_iter()
-                .filter_map(|entry| entry.ok())
+                .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| {
-                    Some(LocalFile::new(entry.path()).ok()?)
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -122,11 +120,9 @@ impl FileProvider for LiveSystemProvider {
         sort_files(
             WalkDir::new(path)
                 .into_iter()
-                .filter_map(|entry| entry.ok())
+                .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| {
-                    Some(LocalFile::new(entry.path()).ok()?)
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -221,7 +217,7 @@ impl FileProvider for LiveSystemProvider {
             ) {
                 return None;
             }
-            Some(LocalFile::new(entry.ok()?.path()).ok()?)
+            LocalFile::new(entry.ok()?.path()).ok()
         }))
     }
 
@@ -230,11 +226,9 @@ impl FileProvider for LiveSystemProvider {
         sort_files(
             WalkDir::new(path)
                 .into_iter()
-                .filter_map(|entry| entry.ok())
+                .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| {
-                    Some(LocalFile::new(entry.path()).ok()?)
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 }
@@ -283,23 +277,19 @@ impl FileProvider for LogarchiveProvider {
             WalkDir::new(&self.base)
                 .sort_by(|a, b| a.file_name().cmp(b.file_name()))
                 .into_iter()
-                .filter_map(|entry| entry.ok())
+                .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| {
-                    Some(LocalFile::new(entry.path()).ok()?)
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
     fn uuidtext_files(&self) -> impl Iterator<Item = impl SourceFile> {
-        Box::new(
+        sort_files(
             WalkDir::new(&self.base)
                 .into_iter()
-                .filter_map(|entry| entry.ok())
+                .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| {
-                    Some(LocalFile::new(entry.path()).ok()?)
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -387,26 +377,22 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn dsc_files(&self) -> impl Iterator<Item = impl SourceFile> {
-        Box::new(
+        sort_files(
             WalkDir::new(&self.base)
                 .into_iter()
-                .filter_map(|entry| entry.ok())
+                .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Dsc))
-                .filter_map(|entry| {
-                    Some(LocalFile::new(entry.path()).ok()?)
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
     fn timesync_files(&self) -> impl Iterator<Item = impl SourceFile> {
-        Box::new(
+        sort_files(
             WalkDir::new(&self.base)
                 .into_iter()
-                .filter_map(|entry| entry.ok())
+                .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| {
-                    Some(LocalFile::new(entry.path()).ok()?)
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -2,7 +2,6 @@ use crate::dsc::SharedCacheStrings;
 use crate::traits::{FileProvider, SourceFile};
 use crate::uuidtext::UUIDText;
 use log::error;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Error, ErrorKind};
 use std::path::{Component, Path, PathBuf};
@@ -42,17 +41,11 @@ impl SourceFile for LocalFile {
 ///    let provider = LiveSystemProvider::default();
 /// ```
 #[derive(Default, Debug)]
-pub struct LiveSystemProvider {
-    pub(crate) uuidtext_cache: HashMap<String, UUIDText>,
-    pub(crate) dsc_cache: HashMap<String, SharedCacheStrings>,
-}
+pub struct LiveSystemProvider;
 
 impl LiveSystemProvider {
     pub fn new() -> Self {
-        Self {
-            uuidtext_cache: HashMap::new(),
-            dsc_cache: HashMap::new(),
-        }
+        Self
     }
 }
 
@@ -140,10 +133,8 @@ impl FileProvider for LiveSystemProvider {
     fn read_uuidtext(&self, uuid: &str) -> Result<UUIDText, Error> {
         let uuid_len = 32;
         let uuid = if uuid.len() == uuid_len - 1 {
-            // UUID starts with 0 which was not included in the string
             &format!("0{uuid}")
         } else if uuid.len() == uuid_len - 2 {
-            // UUID starts with 00 which was not included in the string
             &format!("00{uuid}")
         } else if uuid.len() == uuid_len {
             uuid
@@ -158,7 +149,6 @@ impl FileProvider for LiveSystemProvider {
         let filename = &uuid[2..];
 
         let mut path = PathBuf::from("/private/var/db/uuidtext");
-
         path.push(dir_name);
         path.push(filename);
 
@@ -183,64 +173,11 @@ impl FileProvider for LiveSystemProvider {
         Ok(uuid_text)
     }
 
-    fn cached_uuidtext(&self, uuid: &str) -> Option<&UUIDText> {
-        self.uuidtext_cache.get(uuid)
-    }
-
-    fn update_uuid(&mut self, uuid: &str, uuid2: &str) {
-        let status = match self.read_uuidtext(uuid) {
-            Ok(result) => result,
-            Err(_err) => return,
-        };
-        // Keep a cache of 30 UUIDText files
-        if self.uuidtext_cache.len() > 30 {
-            for key in self
-                .uuidtext_cache
-                .keys()
-                .take(5)
-                .cloned()
-                .collect::<Vec<String>>()
-            {
-                if key == uuid || key == uuid2 {
-                    continue;
-                }
-                let key = key.clone();
-                self.uuidtext_cache.remove(&key);
-            }
-        }
-        self.uuidtext_cache.insert(uuid.to_string(), status);
-    }
-
-    fn update_dsc(&mut self, uuid: &str, uuid2: &str) {
-        let status = match self.read_dsc_uuid(uuid) {
-            Ok(result) => result,
-            Err(_err) => return,
-        };
-        // Keep a cache of 2 DSC UUID files. These files are larger than typical UUID files. ~30MB - ~150MB
-        // However, there are only a few of them. ~5 - 6
-        while self.dsc_cache.len() > 2 {
-            if let Some(key) = self.dsc_cache.keys().next() {
-                if key == uuid || key == uuid2 {
-                    continue;
-                }
-                let key = key.clone();
-                self.dsc_cache.remove(&key);
-            }
-        }
-        self.dsc_cache.insert(uuid.to_string(), status);
-    }
-
-    fn cached_dsc(&self, uuid: &str) -> Option<&SharedCacheStrings> {
-        self.dsc_cache.get(uuid)
-    }
-
     fn read_dsc_uuid(&self, uuid: &str) -> Result<SharedCacheStrings, Error> {
         let uuid_len = 32;
         let uuid = if uuid.len() == uuid_len - 1 {
-            // UUID starts with 0 which was not included in the string
             &format!("0{uuid}")
         } else if uuid.len() == uuid_len - 2 {
-            // UUID starts with 00 which was not included in the string
             &format!("00{uuid}")
         } else if uuid.len() == uuid_len {
             uuid
@@ -315,16 +252,12 @@ impl FileProvider for LiveSystemProvider {
 /// ```
 pub struct LogarchiveProvider {
     base: PathBuf,
-    pub(crate) uuidtext_cache: HashMap<String, UUIDText>,
-    pub(crate) dsc_cache: HashMap<String, SharedCacheStrings>,
 }
 
 impl LogarchiveProvider {
     pub fn new(path: &Path) -> Self {
         Self {
             base: path.to_path_buf(),
-            uuidtext_cache: HashMap::new(),
-            dsc_cache: HashMap::new(),
         }
     }
 }
@@ -373,10 +306,8 @@ impl FileProvider for LogarchiveProvider {
     fn read_uuidtext(&self, uuid: &str) -> Result<UUIDText, Error> {
         let uuid_len = 32;
         let uuid = if uuid.len() == uuid_len - 1 {
-            // UUID starts with 0 which was not included in the string
             &format!("0{uuid}")
         } else if uuid.len() == uuid_len - 2 {
-            // UUID starts with 00 which was not included in the string
             &format!("00{uuid}")
         } else if uuid.len() == uuid_len {
             uuid
@@ -418,10 +349,8 @@ impl FileProvider for LogarchiveProvider {
     fn read_dsc_uuid(&self, uuid: &str) -> Result<SharedCacheStrings, Error> {
         let uuid_len = 32;
         let uuid = if uuid.len() == uuid_len - 1 {
-            // UUID starts with 0 which was not included in the string
             &format!("0{uuid}")
         } else if uuid.len() == uuid_len - 2 {
-            // UUID starts with 00 which was not included in the string
             &format!("00{uuid}")
         } else if uuid.len() == uuid_len {
             uuid
@@ -457,14 +386,6 @@ impl FileProvider for LogarchiveProvider {
         Ok(uuid_text)
     }
 
-    fn cached_uuidtext(&self, uuid: &str) -> Option<&UUIDText> {
-        self.uuidtext_cache.get(uuid)
-    }
-
-    fn cached_dsc(&self, uuid: &str) -> Option<&SharedCacheStrings> {
-        self.dsc_cache.get(uuid)
-    }
-
     fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
         sort_files(
             WalkDir::new(&self.base)
@@ -475,49 +396,6 @@ impl FileProvider for LogarchiveProvider {
                     Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
                 }),
         )
-    }
-
-    fn update_uuid(&mut self, uuid: &str, uuid2: &str) {
-        let status = match self.read_uuidtext(uuid) {
-            Ok(result) => result,
-            Err(_err) => return,
-        };
-        // Keep a cache of 30 UUIDText files
-        if self.uuidtext_cache.len() > 30 {
-            for key in self
-                .uuidtext_cache
-                .keys()
-                .take(5)
-                .cloned()
-                .collect::<Vec<String>>()
-            {
-                if key == uuid || key == uuid2 {
-                    continue;
-                }
-                let key = key.clone();
-                self.uuidtext_cache.remove(&key);
-            }
-        }
-        self.uuidtext_cache.insert(uuid.to_string(), status);
-    }
-
-    fn update_dsc(&mut self, uuid: &str, uuid2: &str) {
-        let status = match self.read_dsc_uuid(uuid) {
-            Ok(result) => result,
-            Err(_err) => return,
-        };
-        // Keep a cache of 2 DSC UUID files. These files are larger than typical UUID files. ~30MB - ~150MB
-        // However, there are only a few of them. ~5 - 6
-        while self.dsc_cache.len() > 2 {
-            if let Some(key) = self.dsc_cache.keys().next() {
-                if key == uuid || key == uuid2 {
-                    continue;
-                }
-                let key = key.clone();
-                self.dsc_cache.remove(&key);
-            }
-        }
-        self.dsc_cache.insert(uuid.to_string(), status);
     }
 
     fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -3,7 +3,7 @@ use crate::traits::{FileProvider, SourceFile};
 use crate::uuidtext::UUIDText;
 use log::error;
 use std::fs::File;
-use std::io::{Error, ErrorKind};
+use std::io::{Error, ErrorKind, Read};
 use std::path::{Component, Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -22,8 +22,8 @@ impl LocalFile {
 }
 
 impl SourceFile for LocalFile {
-    fn reader(&mut self) -> Box<&mut dyn std::io::Read> {
-        Box::new(&mut self.reader)
+    fn reader(&mut self) -> impl std::io::Read {
+        &mut self.reader
     }
 
     fn source_path(&self) -> &str {
@@ -103,7 +103,7 @@ impl From<&Path> for LogFileType {
 }
 
 impl FileProvider for LiveSystemProvider {
-    fn tracev3_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
+    fn tracev3_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/diagnostics");
         sort_files(
             WalkDir::new(path)
@@ -112,12 +112,12 @@ impl FileProvider for LiveSystemProvider {
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
                 .filter_map(|entry| {
-                    Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
+                    Some(LocalFile::new(entry.path()).ok()?)
                 }),
         )
     }
 
-    fn uuidtext_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
+    fn uuidtext_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/uuidtext");
         sort_files(
             WalkDir::new(path)
@@ -125,7 +125,7 @@ impl FileProvider for LiveSystemProvider {
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
                 .filter_map(|entry| {
-                    Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
+                    Some(LocalFile::new(entry.path()).ok()?)
                 }),
         )
     }
@@ -212,7 +212,7 @@ impl FileProvider for LiveSystemProvider {
         Ok(uuid_text)
     }
 
-    fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
+    fn dsc_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/uuidtext/dsc");
         sort_files(WalkDir::new(path).into_iter().filter_map(|entry| {
             if !matches!(
@@ -221,11 +221,11 @@ impl FileProvider for LiveSystemProvider {
             ) {
                 return None;
             }
-            Some(Box::new(LocalFile::new(entry.ok()?.path()).ok()?) as Box<dyn SourceFile>)
+            Some(LocalFile::new(entry.ok()?.path()).ok()?)
         }))
     }
 
-    fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
+    fn timesync_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/diagnostics/timesync");
         sort_files(
             WalkDir::new(path)
@@ -233,7 +233,7 @@ impl FileProvider for LiveSystemProvider {
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
                 .filter_map(|entry| {
-                    Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
+                    Some(LocalFile::new(entry.path()).ok()?)
                 }),
         )
     }
@@ -267,7 +267,7 @@ impl FileProvider for LogarchiveProvider {
     /// # Example
     /// ```rust
     ///    use macos_unifiedlogs::filesystem::LogarchiveProvider;
-    ///    use macos_unifiedlogs::traits::FileProvider;
+    ///    use macos_unifiedlogs::traits::{FileProvider, SourceFile};
     ///    use macos_unifiedlogs::parser::collect_timesync;
     ///    use std::path::PathBuf;
     ///
@@ -278,27 +278,27 @@ impl FileProvider for LogarchiveProvider {
     ///      println!("TraceV3 file: {}", entry.source_path());
     ///    }
     /// ```
-    fn tracev3_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_files(
+    fn tracev3_files(&self) -> impl Iterator<Item = impl SourceFile> {
+        Box::new(
             WalkDir::new(&self.base)
                 .sort_by(|a, b| a.file_name().cmp(b.file_name()))
                 .into_iter()
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
                 .filter_map(|entry| {
-                    Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
+                    Some(LocalFile::new(entry.path()).ok()?)
                 }),
         )
     }
 
-    fn uuidtext_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_files(
+    fn uuidtext_files(&self) -> impl Iterator<Item = impl SourceFile> {
+        Box::new(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
                 .filter_map(|entry| {
-                    Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
+                    Some(LocalFile::new(entry.path()).ok()?)
                 }),
         )
     }
@@ -386,26 +386,26 @@ impl FileProvider for LogarchiveProvider {
         Ok(uuid_text)
     }
 
-    fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_files(
+    fn dsc_files(&self) -> impl Iterator<Item = impl SourceFile> {
+        Box::new(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Dsc))
                 .filter_map(|entry| {
-                    Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
+                    Some(LocalFile::new(entry.path()).ok()?)
                 }),
         )
     }
 
-    fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
-        sort_files(
+    fn timesync_files(&self) -> impl Iterator<Item = impl SourceFile> {
+        Box::new(
             WalkDir::new(&self.base)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
                 .filter_map(|entry| {
-                    Some(Box::new(LocalFile::new(entry.path()).ok()?) as Box<dyn SourceFile>)
+                    Some(LocalFile::new(entry.path()).ok()?)
                 }),
         )
     }
@@ -416,8 +416,8 @@ impl FileProvider for LogarchiveProvider {
 /// Not having it would cause parsing differences across systems
 /// (macOS does not guarantee order of files returned by the filesystem).
 fn sort_files(
-    files: impl Iterator<Item = Box<dyn SourceFile>>,
-) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>> {
+    files: impl Iterator<Item = impl SourceFile>,
+) -> impl Iterator<Item = impl SourceFile> {
     let mut files = files.collect::<Vec<_>>();
     files.sort_by(|a, b| a.source_path().cmp(b.source_path()));
     Box::new(files.into_iter())

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -111,9 +111,7 @@ impl FileProvider for LiveSystemProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| {
-                    LocalFile::new(entry.path()).ok()
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -124,9 +122,7 @@ impl FileProvider for LiveSystemProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| {
-                    LocalFile::new(entry.path()).ok()
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -232,9 +228,7 @@ impl FileProvider for LiveSystemProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| {
-                    LocalFile::new(entry.path()).ok()
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 }
@@ -285,9 +279,7 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| {
-                    LocalFile::new(entry.path()).ok()
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -297,9 +289,7 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| {
-                    LocalFile::new(entry.path()).ok()
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -392,9 +382,7 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Dsc))
-                .filter_map(|entry| {
-                    LocalFile::new(entry.path()).ok()
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 
@@ -404,9 +392,7 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| {
-                    LocalFile::new(entry.path()).ok()
-                }),
+                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
         )
     }
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -111,7 +111,9 @@ impl FileProvider for LiveSystemProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
+                .filter_map(|entry| {
+                    LocalFile::new(entry.path()).ok()
+                }),
         )
     }
 
@@ -122,7 +124,9 @@ impl FileProvider for LiveSystemProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
+                .filter_map(|entry| {
+                    LocalFile::new(entry.path()).ok()
+                }),
         )
     }
 
@@ -228,7 +232,9 @@ impl FileProvider for LiveSystemProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
+                .filter_map(|entry| {
+                    LocalFile::new(entry.path()).ok()
+                }),
         )
     }
 }
@@ -279,7 +285,9 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
+                .filter_map(|entry| {
+                    LocalFile::new(entry.path()).ok()
+                }),
         )
     }
 
@@ -289,7 +297,9 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
+                .filter_map(|entry| {
+                    LocalFile::new(entry.path()).ok()
+                }),
         )
     }
 
@@ -382,7 +392,9 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Dsc))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
+                .filter_map(|entry| {
+                    LocalFile::new(entry.path()).ok()
+                }),
         )
     }
 
@@ -392,7 +404,9 @@ impl FileProvider for LogarchiveProvider {
                 .into_iter()
                 .filter_map(Result::ok)
                 .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
+                .filter_map(|entry| {
+                    LocalFile::new(entry.path()).ok()
+                }),
         )
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -137,7 +137,7 @@ fn nom_bytes<'a>(data: &'a [u8], size: &u64) -> nom::IResult<&'a [u8], &'a [u8]>
 mod tests {
     use super::UnifiedLogIterator;
     use crate::{
-        cache::StringCache, filesystem::LogarchiveProvider, iterator::nom_bytes, parser::{build_log, collect_timesync}, unified_log::{EventType, LogType}
+        cache::MemoryStringCache, filesystem::LogarchiveProvider, iterator::nom_bytes, parser::{build_log, collect_timesync}, unified_log::{EventType, LogType}
     };
     use std::{fs, path::PathBuf};
 
@@ -194,12 +194,12 @@ mod tests {
             evidence: String::from("0000000000000002.tracev3"),
         };
 
-        let mut cache = StringCache::new();
+        let mut cache = MemoryStringCache::default();
 
         let mut total = 0;
         for chunk in log_iterator {
             let exclude_missing = false;
-            let (results, _) = build_log(&chunk, &mut provider, &mut cache, &timesync_data, exclude_missing);
+            let (results, _) = build_log(&chunk, &mut provider, &cache, &timesync_data, exclude_missing);
 
             if results[10].time == 1642302327364384800.0 {
                 assert_eq!(results.len(), 3805);

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -137,7 +137,11 @@ fn nom_bytes<'a>(data: &'a [u8], size: &u64) -> nom::IResult<&'a [u8], &'a [u8]>
 mod tests {
     use super::UnifiedLogIterator;
     use crate::{
-        cache::MemoryStringCache, filesystem::LogarchiveProvider, iterator::nom_bytes, parser::{build_log, collect_timesync}, unified_log::{EventType, LogType}
+        cache::MemoryStringCache,
+        filesystem::LogarchiveProvider,
+        iterator::nom_bytes,
+        parser::{build_log, collect_timesync},
+        unified_log::{EventType, LogType},
     };
     use std::{fs, path::PathBuf};
 
@@ -199,7 +203,13 @@ mod tests {
         let mut total = 0;
         for chunk in log_iterator {
             let exclude_missing = false;
-            let (results, _) = build_log(&chunk, &mut provider, &cache, &timesync_data, exclude_missing);
+            let (results, _) = build_log(
+                &chunk,
+                &mut provider,
+                &cache,
+                &timesync_data,
+                exclude_missing,
+            );
 
             if results[10].time == 1642302327364384800.0 {
                 assert_eq!(results.len(), 3805);

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -137,10 +137,7 @@ fn nom_bytes<'a>(data: &'a [u8], size: &u64) -> nom::IResult<&'a [u8], &'a [u8]>
 mod tests {
     use super::UnifiedLogIterator;
     use crate::{
-        filesystem::LogarchiveProvider,
-        iterator::nom_bytes,
-        parser::{build_log, collect_timesync},
-        unified_log::{EventType, LogType},
+        cache::StringCache, filesystem::LogarchiveProvider, iterator::nom_bytes, parser::{build_log, collect_timesync}, unified_log::{EventType, LogType}
     };
     use std::{fs, path::PathBuf};
 
@@ -197,10 +194,12 @@ mod tests {
             evidence: String::from("0000000000000002.tracev3"),
         };
 
+        let mut cache = StringCache::new();
+
         let mut total = 0;
         for chunk in log_iterator {
             let exclude_missing = false;
-            let (results, _) = build_log(&chunk, &mut provider, &timesync_data, exclude_missing);
+            let (results, _) = build_log(&chunk, &mut provider, &mut cache, &timesync_data, exclude_missing);
 
             if results[10].time == 1642302327364384800.0 {
                 assert_eq!(results.len(), 3805);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,16 +37,17 @@
 //! ## Example
 //! ```rust
 //!    use macos_unifiedlogs::filesystem::LiveSystemProvider;
-//!    use macos_unifiedlogs::traits::FileProvider;
-//!    use macos_unifiedlogs::cache::StringCache;
+//!    use macos_unifiedlogs::traits::{FileProvider, SourceFile};
+//!    use macos_unifiedlogs::cache::MemoryStringCache;
 //!    use macos_unifiedlogs::parser::collect_timesync;
 //!    use macos_unifiedlogs::iterator::UnifiedLogIterator;
 //!    use macos_unifiedlogs::unified_log::UnifiedLogData;
 //!    use macos_unifiedlogs::parser::build_log;
+//!    use std::io::Read;
 //!
 //!    // Run on live macOS system
 //!     let provider = LiveSystemProvider::default();
-//!     let cache = StringCache::new();
+//!     let cache = MemoryStringCache::default();
 //!     let timesync_data = collect_timesync(&provider).unwrap();
 //!
 //!     // We need to persist the Oversize log entries (they contain large strings that don't fit in normal log entries)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,13 +38,15 @@
 //! ```rust
 //!    use macos_unifiedlogs::filesystem::LiveSystemProvider;
 //!    use macos_unifiedlogs::traits::FileProvider;
+//!    use macos_unifiedlogs::cache::StringCache;
 //!    use macos_unifiedlogs::parser::collect_timesync;
 //!    use macos_unifiedlogs::iterator::UnifiedLogIterator;
 //!    use macos_unifiedlogs::unified_log::UnifiedLogData;
 //!    use macos_unifiedlogs::parser::build_log;
 //!
 //!    // Run on live macOS system
-//!     let mut provider = LiveSystemProvider::default();
+//!     let provider = LiveSystemProvider::default();
+//!     let cache = StringCache::new();
 //!     let timesync_data = collect_timesync(&provider).unwrap();
 //!
 //!     // We need to persist the Oversize log entries (they contain large strings that don't fit in normal log entries)
@@ -69,7 +71,8 @@
 //!             chunk.oversize.append(&mut oversize_strings.oversize);
 //!             let (results, _missing_logs) = build_log(
 //!                 &chunk,
-//!                 &mut provider,
+//!                 &provider,
+//!                 &cache,
 //!                 &timesync_data,
 //!                 exclude,
 //!             );
@@ -88,6 +91,8 @@ mod chunks;
 mod chunkset;
 /// Parsers to extract specific log objects
 mod decoders;
+/// Thread-safe cache for UUIDText and SharedCacheStrings used during log parsing
+pub mod cache;
 /// Functions to parse the shared string cache
 pub mod dsc;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,14 +86,14 @@
 //!
 //! ```
 
+/// Thread-safe cache for UUIDText and SharedCacheStrings used during log parsing
+pub mod cache;
 /// Functions to parse catalog information from tracev3 files
 mod catalog;
 mod chunks;
 mod chunkset;
 /// Parsers to extract specific log objects
 mod decoders;
-/// Thread-safe cache for UUIDText and SharedCacheStrings used during log parsing
-pub mod cache;
 /// Functions to parse the shared string cache
 pub mod dsc;
 mod error;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ use log::{error, info};
 use crate::dsc::SharedCacheStrings;
 use crate::error::ParserError;
 use crate::timesync::TimesyncBoot;
-use crate::traits::{FileProvider, StringCache, SourceFile};
+use crate::traits::{FileProvider, SourceFile, StringCache};
 use crate::unified_log::{LogData, UnifiedLogData};
 use crate::uuidtext::UUIDText;
 use std::collections::HashMap;
@@ -98,7 +98,13 @@ pub fn build_log(
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) -> (Vec<LogData>, UnifiedLogData) {
-    LogData::build_log(unified_data, provider, cache, timesync_data, exclude_missing)
+    LogData::build_log(
+        unified_data,
+        provider,
+        cache,
+        timesync_data,
+        exclude_missing,
+    )
 }
 
 /// Parse all UUID files in provided directory. The directory should follow the same layout as the live system (ex: path/to/files/\<two character UUID\>/\<remaining UUID name\>)
@@ -427,7 +433,13 @@ mod tests {
         let timesync_data = collect_timesync(&provider).unwrap();
 
         let exclude_missing = false;
-        let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+        let (results, _) = build_log(
+            &log_data,
+            &provider,
+            &cache,
+            &timesync_data,
+            exclude_missing,
+        );
         assert_eq!(results.len(), 207366);
         assert_eq!(results[10].process, "/usr/libexec/lightsoutmanagementd");
         assert_eq!(results[10].subsystem, "com.apple.lom");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@
 
 use log::{error, info};
 
+use crate::cache::StringCache;
 use crate::dsc::SharedCacheStrings;
 use crate::error::ParserError;
 use crate::timesync::TimesyncBoot;
@@ -46,6 +47,7 @@ pub fn parse_log(mut reader: impl Read, evidence: &str) -> Result<UnifiedLogData
 ///    use macos_unifiedlogs::iterator::UnifiedLogIterator;
 ///    use macos_unifiedlogs::unified_log::UnifiedLogData;
 ///    use macos_unifiedlogs::parser::build_log;
+///    use macos_unifiedlogs::cache::StringCache;
 ///    use std::path::PathBuf;
 ///
 ///    let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -60,6 +62,8 @@ pub fn parse_log(mut reader: impl Read, evidence: &str) -> Result<UnifiedLogData
 ///        oversize: Vec::new(),
 ///        evidence: String::new(),
 ///    };
+///
+///    let cache = StringCache::new();
 ///    for mut entry in provider.tracev3_files() {
 ///      println!("TraceV3 file: {}", entry.source_path());
 ///      let mut buf = Vec::new();
@@ -75,7 +79,8 @@ pub fn parse_log(mut reader: impl Read, evidence: &str) -> Result<UnifiedLogData
 ///        chunk.oversize.append(&mut oversize_strings.oversize);
 ///        let (results, _missing_logs) = build_log(
 ///            &chunk,
-///            &mut provider,
+///            &provider,
+///            &cache,
 ///            &timesync_data,
 ///            exclude,
 ///        );
@@ -88,11 +93,12 @@ pub fn parse_log(mut reader: impl Read, evidence: &str) -> Result<UnifiedLogData
 /// ```
 pub fn build_log(
     unified_data: &UnifiedLogData,
-    provider: &mut dyn FileProvider,
+    provider: &dyn FileProvider,
+    cache: &StringCache,
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) -> (Vec<LogData>, UnifiedLogData) {
-    LogData::build_log(unified_data, provider, timesync_data, exclude_missing)
+    LogData::build_log(unified_data, provider, cache, timesync_data, exclude_missing)
 }
 
 /// Parse all UUID files in provided directory. The directory should follow the same layout as the live system (ex: path/to/files/\<two character UUID\>/\<remaining UUID name\>)
@@ -411,7 +417,8 @@ mod tests {
     fn test_build_log() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = crate::cache::StringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();
@@ -420,7 +427,7 @@ mod tests {
         let timesync_data = collect_timesync(&provider).unwrap();
 
         let exclude_missing = false;
-        let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+        let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
         assert_eq!(results.len(), 207366);
         assert_eq!(results[10].process, "/usr/libexec/lightsoutmanagementd");
         assert_eq!(results[10].subsystem, "com.apple.lom");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ use log::{error, info};
 use crate::dsc::SharedCacheStrings;
 use crate::error::ParserError;
 use crate::timesync::TimesyncBoot;
-use crate::traits::{FileProvider, StringCache};
+use crate::traits::{FileProvider, StringCache, SourceFile};
 use crate::unified_log::{LogData, UnifiedLogData};
 use crate::uuidtext::UUIDText;
 use std::collections::HashMap;
@@ -41,13 +41,14 @@ pub fn parse_log(mut reader: impl Read, evidence: &str) -> Result<UnifiedLogData
 /// # Example
 /// ```rust
 ///    use macos_unifiedlogs::filesystem::LogarchiveProvider;
-///    use macos_unifiedlogs::traits::FileProvider;
+///    use macos_unifiedlogs::traits::{FileProvider, SourceFile};
 ///    use macos_unifiedlogs::parser::collect_timesync;
 ///    use macos_unifiedlogs::iterator::UnifiedLogIterator;
 ///    use macos_unifiedlogs::unified_log::UnifiedLogData;
 ///    use macos_unifiedlogs::parser::build_log;
-///    use macos_unifiedlogs::cache::StringCache;
+///    use macos_unifiedlogs::cache::MemoryStringCache;
 ///    use std::path::PathBuf;
+///    use std::io::Read;
 ///
 ///    let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 ///    test_path.push("tests/test_data/system_logs_big_sur.logarchive");
@@ -62,7 +63,7 @@ pub fn parse_log(mut reader: impl Read, evidence: &str) -> Result<UnifiedLogData
 ///        evidence: String::new(),
 ///    };
 ///
-///    let cache = StringCache::new();
+///    let cache = MemoryStringCache::default();
 ///    for mut entry in provider.tracev3_files() {
 ///      println!("TraceV3 file: {}", entry.source_path());
 ///      let mut buf = Vec::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,11 +7,10 @@
 
 use log::{error, info};
 
-use crate::cache::StringCache;
 use crate::dsc::SharedCacheStrings;
 use crate::error::ParserError;
 use crate::timesync::TimesyncBoot;
-use crate::traits::FileProvider;
+use crate::traits::{FileProvider, StringCache};
 use crate::unified_log::{LogData, UnifiedLogData};
 use crate::uuidtext::UUIDText;
 use std::collections::HashMap;
@@ -93,8 +92,8 @@ pub fn parse_log(mut reader: impl Read, evidence: &str) -> Result<UnifiedLogData
 /// ```
 pub fn build_log(
     unified_data: &UnifiedLogData,
-    provider: &dyn FileProvider,
-    cache: &StringCache,
+    provider: &impl FileProvider,
+    cache: &impl StringCache,
     timesync_data: &HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
 ) -> (Vec<LogData>, UnifiedLogData) {
@@ -102,7 +101,7 @@ pub fn build_log(
 }
 
 /// Parse all UUID files in provided directory. The directory should follow the same layout as the live system (ex: path/to/files/\<two character UUID\>/\<remaining UUID name\>)
-pub fn collect_strings(provider: &dyn FileProvider) -> Result<Vec<UUIDText>, ParserError> {
+pub fn collect_strings(provider: &impl FileProvider) -> Result<Vec<UUIDText>, ParserError> {
     let mut uuidtext_vec: Vec<UUIDText> = Vec::new();
     // Start process to read a directory containing subdirectories that contain the uuidtext files
     for mut source in provider.uuidtext_files() {
@@ -136,7 +135,7 @@ pub fn collect_strings(provider: &dyn FileProvider) -> Result<Vec<UUIDText>, Par
 
 /// Parse all dsc uuid files in provided directory
 pub fn collect_shared_strings(
-    provider: &dyn FileProvider,
+    provider: &impl FileProvider,
 ) -> Result<Vec<SharedCacheStrings>, ParserError> {
     let mut shared_strings_vec: Vec<SharedCacheStrings> = Vec::new();
     // Start process to read and parse uuid files related to dsc
@@ -177,7 +176,7 @@ pub fn collect_shared_strings(
 ///    let timesync_data = collect_timesync(&provider).unwrap();
 /// ```
 pub fn collect_timesync(
-    provider: &dyn FileProvider,
+    provider: &impl FileProvider,
 ) -> Result<HashMap<String, TimesyncBoot>, ParserError> {
     let mut timesync_data: HashMap<String, TimesyncBoot> = HashMap::new();
     // Start process to read and parse all timesync files
@@ -418,7 +417,7 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = crate::cache::StringCache::default();
+        let cache = crate::cache::MemoryStringCache::default();
 
         test_path.push("Persist/0000000000000002.tracev3");
         let handle = std::fs::File::open(&test_path).unwrap();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,5 @@
-use std::io::Error;
+use std::borrow::Borrow;
+use std::{hash::Hash, io::Error};
 use std::sync::Arc;
 
 use crate::{dsc::SharedCacheStrings, uuidtext::UUIDText};
@@ -50,6 +51,20 @@ pub trait SourceFile {
     /// The source path of the file on the machine from which it was collected, distinct from any
     /// secondary storage location where, for instance, a file backing the `reader` might exist.
     fn source_path(&self) -> &str;
+}
+
+
+pub trait Cache<K, V>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    fn get<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized;
+
+    fn insert(&self, key: K, value: V) -> Option<V>;
 }
 
 /// Defines a trait for caching string values parsed from the `dsc` or `uuidtext` directories.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,5 @@
 use std::io::Error;
+use std::sync::Arc;
 
 use crate::{dsc::SharedCacheStrings, uuidtext::UUIDText};
 
@@ -49,4 +50,19 @@ pub trait SourceFile {
     /// The source path of the file on the machine from which it was collected, distinct from any
     /// secondary storage location where, for instance, a file backing the `reader` might exist.
     fn source_path(&self) -> &str;
+}
+
+/// Defines a trait for caching string values parsed from the `dsc` or `uuidtext` directories.
+pub trait StringCache: Sync {
+    fn get_or_load_uuidtext(
+        &self,
+        uuid: &str,
+        provider: &dyn FileProvider,
+    ) -> Option<Arc<UUIDText>>;
+
+    fn get_or_load_dsc(
+        &self,
+        uuid: &str,
+        provider: &dyn FileProvider,
+    ) -> Option<Arc<SharedCacheStrings>>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
-use std::{hash::Hash, io::Error};
 use std::sync::Arc;
+use std::{hash::Hash, io::Error};
 
 use crate::{dsc::SharedCacheStrings, uuidtext::UUIDText};
 
@@ -52,7 +52,6 @@ pub trait SourceFile {
     /// secondary storage location where, for instance, a file backing the `reader` might exist.
     fn source_path(&self) -> &str;
 }
-
 
 pub trait Cache<K, V>
 where

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -26,12 +26,6 @@ pub trait FileProvider {
     /// This avoids having to read all `UUIDText` files into memory.
     fn read_uuidtext(&self, uuid: &str) -> Result<UUIDText, Error>;
 
-    /// Check our cached `UUIDText` data for strings
-    fn cached_uuidtext(&self, uuid: &str) -> Option<&UUIDText>;
-
-    /// Update our cached `UUIDText` data
-    fn update_uuid(&mut self, uuid: &str, uuid2: &str);
-
     /// Provides an iterator of shared string files from the `/var/db/uuidtext/dsc` subdirectory,
     /// along with the filename (i.e., the filename from the _source_ file). This should be a
     /// 30-character name containing only hex digits. It is important that this is. accurate, or
@@ -42,12 +36,6 @@ pub trait FileProvider {
     /// The UUID is obtaind by parsing the `tracev3` files. Reads will fail if the UUID does not exist
     /// This avoids having to read all `SharedCacheStrings` files into memory.
     fn read_dsc_uuid(&self, uuid: &str) -> Result<SharedCacheStrings, Error>;
-
-    /// Check our cached `SharedCacheStrings` for strings
-    fn cached_dsc(&self, uuid: &str) -> Option<&SharedCacheStrings>;
-
-    /// Update our cached `SharedCacheStrings` data
-    fn update_dsc(&mut self, uuid: &str, uuid2: &str);
 
     /// Provides an iterator of `.timesync` files from the `/var/db/diagnostics/timesync` subdirectory.
     fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,14 +13,14 @@ pub trait FileProvider {
     /// Provides an iterator of `.tracev3` files from the
     /// `/private/var/db/diagnostics/((HighVolume|Signpost|Trace|Special)/`, plus the
     /// `livedata.LogData.tracev3` file if it was collected via `log collect`.
-    fn tracev3_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>>;
+    fn tracev3_files(&self) -> impl Iterator<Item = impl SourceFile>;
 
     /// Provides an iterator of `UUIDText` string files from the `/var/db/uuidtext/XX/` directories,
     /// where the `XX` is any two uppercase hex characters, along with the filename (i.e., the
     /// filename from the _source_ file. This should be a 30-character name containing only hex
     /// digits. This should be a 30-character name containing only hex digits. It is important that
     /// this is. accurate, or else strings will not be able to be referenced from the source file.
-    fn uuidtext_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>>;
+    fn uuidtext_files(&self) -> impl Iterator<Item = impl SourceFile>;
 
     /// Reads a provided UUID file at runtime.
     /// The UUID is obtaind by parsing the `tracev3` files. Reads will fail if the UUID does not exist
@@ -31,7 +31,7 @@ pub trait FileProvider {
     /// along with the filename (i.e., the filename from the _source_ file). This should be a
     /// 30-character name containing only hex digits. It is important that this is. accurate, or
     /// else strings will not be able to be referenced from the source file.
-    fn dsc_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>>;
+    fn dsc_files(&self) -> impl Iterator<Item = impl SourceFile>;
 
     /// Reads a provided UUID file at runtime.
     /// The UUID is obtaind by parsing the `tracev3` files. Reads will fail if the UUID does not exist
@@ -39,14 +39,14 @@ pub trait FileProvider {
     fn read_dsc_uuid(&self, uuid: &str) -> Result<SharedCacheStrings, Error>;
 
     /// Provides an iterator of `.timesync` files from the `/var/db/diagnostics/timesync` subdirectory.
-    fn timesync_files(&self) -> Box<dyn Iterator<Item = Box<dyn SourceFile>>>;
+    fn timesync_files(&self) -> impl Iterator<Item = impl SourceFile>;
 }
 
 /// Defines an interface for providing a single unified log file. Parsing unified logs requires the
 /// name of the original file in order to reconstruct format strings.
 pub trait SourceFile {
     /// A reader for the given source file.
-    fn reader(&mut self) -> Box<&mut dyn std::io::Read>;
+    fn reader(&mut self) -> impl std::io::Read;
     /// The source path of the file on the machine from which it was collected, distinct from any
     /// secondary storage location where, for instance, a file backing the `reader` might exist.
     fn source_path(&self) -> &str;
@@ -57,12 +57,12 @@ pub trait StringCache: Sync {
     fn get_or_load_uuidtext(
         &self,
         uuid: &str,
-        provider: &dyn FileProvider,
+        provider: &impl FileProvider,
     ) -> Option<Arc<UUIDText>>;
 
     fn get_or_load_dsc(
         &self,
         uuid: &str,
-        provider: &dyn FileProvider,
+        provider: &impl FileProvider,
     ) -> Option<Arc<SharedCacheStrings>>;
 }

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -90,20 +90,20 @@ pub struct UnifiedLogCatalogData {
     pub oversize: Vec<Oversize>,
 }
 
-struct LogIterator<'a> {
+struct LogIterator<'a, P, C> where P: FileProvider, C: StringCache {
     unified_log_data: &'a UnifiedLogData,
-    provider: &'a dyn FileProvider,
-    cache: &'a dyn StringCache,
+    provider: &'a P,
+    cache: &'a C,
     timesync_data: &'a HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
     message_re: Regex,
     catalog_data_iterator_index: usize,
 }
-impl<'a> LogIterator<'a> {
+impl<'a, P, C> LogIterator<'a, P, C> where P: FileProvider, C: StringCache {
     fn new(
         unified_log_data: &'a UnifiedLogData,
-        provider: &'a dyn FileProvider,
-        cache: &'a dyn StringCache,
+        provider: &'a P,
+        cache: &'a C,
         timesync_data: &'a HashMap<String, TimesyncBoot>,
         exclude_missing: bool,
     ) -> Result<Self, regex::Error> {
@@ -153,7 +153,7 @@ impl<'a> LogIterator<'a> {
     }
 }
 
-impl Iterator for LogIterator<'_> {
+impl <P, C>Iterator for LogIterator<'_, P, C> where P: FileProvider, C: StringCache {
     type Item = (Vec<LogData>, UnifiedLogData);
 
     /// `catalog_data_index` == 0
@@ -795,8 +795,8 @@ impl LogData {
     /// Return a reconstructed log entries and any leftover Unified Log entries that could not be reconstructed (data may be stored in other tracev3 files)
     pub fn build_log(
         unified_log_data: &UnifiedLogData,
-        provider: &dyn FileProvider,
-        cache: & dyn StringCache,
+        provider: &impl FileProvider,
+        cache: &impl StringCache,
         timesync_data: &HashMap<String, TimesyncBoot>,
         exclude_missing: bool,
     ) -> (Vec<LogData>, UnifiedLogData) {

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -90,7 +90,11 @@ pub struct UnifiedLogCatalogData {
     pub oversize: Vec<Oversize>,
 }
 
-struct LogIterator<'a, P, C> where P: FileProvider, C: StringCache {
+struct LogIterator<'a, P, C>
+where
+    P: FileProvider,
+    C: StringCache,
+{
     unified_log_data: &'a UnifiedLogData,
     provider: &'a P,
     cache: &'a C,
@@ -99,7 +103,11 @@ struct LogIterator<'a, P, C> where P: FileProvider, C: StringCache {
     message_re: Regex,
     catalog_data_iterator_index: usize,
 }
-impl<'a, P, C> LogIterator<'a, P, C> where P: FileProvider, C: StringCache {
+impl<'a, P, C> LogIterator<'a, P, C>
+where
+    P: FileProvider,
+    C: StringCache,
+{
     fn new(
         unified_log_data: &'a UnifiedLogData,
         provider: &'a P,
@@ -153,7 +161,11 @@ impl<'a, P, C> LogIterator<'a, P, C> where P: FileProvider, C: StringCache {
     }
 }
 
-impl <P, C>Iterator for LogIterator<'_, P, C> where P: FileProvider, C: StringCache {
+impl<P, C> Iterator for LogIterator<'_, P, C>
+where
+    P: FileProvider,
+    C: StringCache,
+{
     type Item = (Vec<LogData>, UnifiedLogData);
 
     /// `catalog_data_index` == 0
@@ -809,9 +821,13 @@ impl LogData {
             evidence: unified_log_data.evidence.clone(),
         };
 
-        let Ok(log_iterator) =
-            LogIterator::new(unified_log_data, provider, cache, timesync_data, exclude_missing)
-        else {
+        let Ok(log_iterator) = LogIterator::new(
+            unified_log_data,
+            provider,
+            cache,
+            timesync_data,
+            exclude_missing,
+        ) else {
             return (log_data_vec, missing_unified_log_data_vec);
         };
         for (mut log_data, mut missing_unified_log) in log_iterator {
@@ -1066,8 +1082,13 @@ mod tests {
         let log_data = parse_log(reader, test_path.to_str().unwrap()).unwrap();
 
         let exclude_missing = false;
-        let (results, _) =
-            LogData::build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+        let (results, _) = LogData::build_log(
+            &log_data,
+            &provider,
+            &cache,
+            &timesync_data,
+            exclude_missing,
+        );
 
         assert_eq!(results.len(), 207366);
         assert_eq!(results[0].process, "/usr/libexec/lightsoutmanagementd");

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -26,9 +26,8 @@ use crate::chunkset::ChunksetChunk;
 use crate::header::HeaderChunk;
 use crate::message::format_firehose_log_message;
 use crate::preamble::LogPreamble;
-use crate::cache::StringCache;
 use crate::timesync::TimesyncBoot;
-use crate::traits::FileProvider;
+use crate::traits::{FileProvider, StringCache};
 use crate::util::{
     encode_standard, extract_string, padding_size_8, u64_to_usize, unixepoch_to_iso,
 };
@@ -94,7 +93,7 @@ pub struct UnifiedLogCatalogData {
 struct LogIterator<'a> {
     unified_log_data: &'a UnifiedLogData,
     provider: &'a dyn FileProvider,
-    cache: &'a StringCache,
+    cache: &'a dyn StringCache,
     timesync_data: &'a HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
     message_re: Regex,
@@ -104,7 +103,7 @@ impl<'a> LogIterator<'a> {
     fn new(
         unified_log_data: &'a UnifiedLogData,
         provider: &'a dyn FileProvider,
-        cache: &'a StringCache,
+        cache: &'a dyn StringCache,
         timesync_data: &'a HashMap<String, TimesyncBoot>,
         exclude_missing: bool,
     ) -> Result<Self, regex::Error> {
@@ -797,7 +796,7 @@ impl LogData {
     pub fn build_log(
         unified_log_data: &UnifiedLogData,
         provider: &dyn FileProvider,
-        cache: &StringCache,
+        cache: & dyn StringCache,
         timesync_data: &HashMap<String, TimesyncBoot>,
         exclude_missing: bool,
     ) -> (Vec<LogData>, UnifiedLogData) {
@@ -970,7 +969,7 @@ impl LogData {
 #[cfg(test)]
 mod tests {
     use super::{LogData, UnifiedLogData};
-    use crate::cache::StringCache;
+    use crate::cache::MemoryStringCache;
     use crate::{
         chunks::firehose::firehose_log::Firehose,
         filesystem::LogarchiveProvider,
@@ -1058,7 +1057,7 @@ mod tests {
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
         let provider = LogarchiveProvider::new(test_path.as_path());
-        let cache = StringCache::default();
+        let cache = MemoryStringCache::default();
         let timesync_data = collect_timesync(&provider).unwrap();
 
         test_path.push("Persist/0000000000000002.tracev3");

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -26,6 +26,7 @@ use crate::chunkset::ChunksetChunk;
 use crate::header::HeaderChunk;
 use crate::message::format_firehose_log_message;
 use crate::preamble::LogPreamble;
+use crate::cache::StringCache;
 use crate::timesync::TimesyncBoot;
 use crate::traits::FileProvider;
 use crate::util::{
@@ -92,7 +93,8 @@ pub struct UnifiedLogCatalogData {
 
 struct LogIterator<'a> {
     unified_log_data: &'a UnifiedLogData,
-    provider: &'a mut dyn FileProvider,
+    provider: &'a dyn FileProvider,
+    cache: &'a StringCache,
     timesync_data: &'a HashMap<String, TimesyncBoot>,
     exclude_missing: bool,
     message_re: Regex,
@@ -101,7 +103,8 @@ struct LogIterator<'a> {
 impl<'a> LogIterator<'a> {
     fn new(
         unified_log_data: &'a UnifiedLogData,
-        provider: &'a mut dyn FileProvider,
+        provider: &'a dyn FileProvider,
+        cache: &'a StringCache,
         timesync_data: &'a HashMap<String, TimesyncBoot>,
         exclude_missing: bool,
     ) -> Result<Self, regex::Error> {
@@ -142,6 +145,7 @@ impl<'a> LogIterator<'a> {
         Ok(LogIterator {
             unified_log_data,
             provider,
+            cache,
             timesync_data,
             exclude_missing,
             message_re,
@@ -234,6 +238,7 @@ impl Iterator for LogIterator<'_> {
                         let message_data = FirehoseNonActivity::get_firehose_nonactivity_strings(
                             &firehose.firehose_non_activity,
                             self.provider,
+                            self.cache,
                             u64::from(firehose.format_string_location),
                             preamble.first_number_proc_id,
                             preamble.second_number_proc_id,
@@ -342,6 +347,7 @@ impl Iterator for LogIterator<'_> {
                         let message_data = FirehoseActivity::get_firehose_activity_strings(
                             &firehose.firehose_activity,
                             self.provider,
+                            self.cache,
                             u64::from(firehose.format_string_location),
                             preamble.first_number_proc_id,
                             preamble.second_number_proc_id,
@@ -397,6 +403,7 @@ impl Iterator for LogIterator<'_> {
                         let message_data = FirehoseSignpost::get_firehose_signpost(
                             &firehose.firehose_signpost,
                             self.provider,
+                            self.cache,
                             u64::from(firehose.format_string_location),
                             preamble.first_number_proc_id,
                             preamble.second_number_proc_id,
@@ -487,6 +494,7 @@ impl Iterator for LogIterator<'_> {
                     0x3 => {
                         let message_data = FirehoseTrace::get_firehose_trace_strings(
                             self.provider,
+                            self.cache,
                             u64::from(firehose.format_string_location),
                             preamble.first_number_proc_id,
                             preamble.second_number_proc_id,
@@ -788,7 +796,8 @@ impl LogData {
     /// Return a reconstructed log entries and any leftover Unified Log entries that could not be reconstructed (data may be stored in other tracev3 files)
     pub fn build_log(
         unified_log_data: &UnifiedLogData,
-        provider: &mut dyn FileProvider,
+        provider: &dyn FileProvider,
+        cache: &StringCache,
         timesync_data: &HashMap<String, TimesyncBoot>,
         exclude_missing: bool,
     ) -> (Vec<LogData>, UnifiedLogData) {
@@ -802,7 +811,7 @@ impl LogData {
         };
 
         let Ok(log_iterator) =
-            LogIterator::new(unified_log_data, provider, timesync_data, exclude_missing)
+            LogIterator::new(unified_log_data, provider, cache, timesync_data, exclude_missing)
         else {
             return (log_data_vec, missing_unified_log_data_vec);
         };
@@ -961,6 +970,7 @@ impl LogData {
 #[cfg(test)]
 mod tests {
     use super::{LogData, UnifiedLogData};
+    use crate::cache::StringCache;
     use crate::{
         chunks::firehose::firehose_log::Firehose,
         filesystem::LogarchiveProvider,
@@ -1047,7 +1057,8 @@ mod tests {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-        let mut provider = LogarchiveProvider::new(test_path.as_path());
+        let provider = LogarchiveProvider::new(test_path.as_path());
+        let cache = StringCache::default();
         let timesync_data = collect_timesync(&provider).unwrap();
 
         test_path.push("Persist/0000000000000002.tracev3");
@@ -1057,7 +1068,7 @@ mod tests {
 
         let exclude_missing = false;
         let (results, _) =
-            LogData::build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+            LogData::build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
 
         assert_eq!(results.len(), 207366);
         assert_eq!(results[0].process, "/usr/libexec/lightsoutmanagementd");

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -6,7 +6,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use macos_unifiedlogs::{
-    cache::StringCache,
+    cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -77,7 +77,7 @@ fn test_big_sur_livedata() {
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -123,7 +123,7 @@ fn test_build_log_big_sur() {
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -167,7 +167,7 @@ fn test_parse_all_logs_big_sur() {
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -316,7 +316,7 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -409,7 +409,7 @@ fn test_parse_all_logs_private_big_sur() {
     test_path.push("tests/test_data/system_logs_big_sur_private_enabled.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -448,7 +448,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur() {
     test_path.push("tests/test_data/system_logs_big_sur_public_private_data_mix.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -510,7 +510,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_single_file() {
     test_path.push("tests/test_data/system_logs_big_sur_public_private_data_mix.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -556,7 +556,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_special_file() {
     test_path.push("tests/test_data/system_logs_big_sur_public_private_data_mix.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -603,7 +603,7 @@ fn test_big_sur_missing_oversize_strings() {
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -635,7 +635,7 @@ fn test_big_sur_oversize_strings_in_another_file() {
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -134,7 +134,13 @@ fn test_build_log_big_sur() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 110953);
     assert_eq!(results[0].process, "/usr/libexec/opendirectoryd");
     assert_eq!(results[0].subsystem, "com.apple.opendirectoryd");
@@ -521,7 +527,13 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_single_file() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 91567);
 
     let mut hex_count = 0;
@@ -567,7 +579,13 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_special_file() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 2238);
 
     let mut statedump = 0;
@@ -615,7 +633,13 @@ fn test_big_sur_missing_oversize_strings() {
     test_path.pop();
 
     let exclude_missing = false;
-    let (data, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (data, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(data.len(), 101566);
 
     let mut missing_strings = 0;

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -6,6 +6,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use macos_unifiedlogs::{
+    cache::StringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -75,7 +76,8 @@ fn test_big_sur_livedata() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -85,7 +87,7 @@ fn test_big_sur_livedata() {
     test_path.pop();
 
     let exclude_missing = false;
-    let (data, _) = build_log(&results, &mut provider, &timesync_data, exclude_missing);
+    let (data, _) = build_log(&results, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(data.len(), 101566);
 
     for results in data {
@@ -120,7 +122,8 @@ fn test_build_log_big_sur() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -131,7 +134,7 @@ fn test_build_log_big_sur() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 110953);
     assert_eq!(results[0].process, "/usr/libexec/opendirectoryd");
     assert_eq!(results[0].subsystem, "com.apple.opendirectoryd");
@@ -163,7 +166,8 @@ fn test_parse_all_logs_big_sur() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -171,7 +175,7 @@ fn test_parse_all_logs_big_sur() {
     let mut log_data_vec: Vec<LogData> = Vec::new();
     let exclude_missing = false;
     for logs in &log_data {
-        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &provider, &cache, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     // Run: "log raw-dump -a macos-unifiedlogs/tests/test_data/system_logs_big_sur.logarchive"
@@ -311,7 +315,8 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -320,7 +325,7 @@ fn test_parse_all_persist_logs_with_network_big_sur() {
     let exclude_missing = false;
 
     for logs in &log_data {
-        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &provider, &cache, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
 
@@ -403,7 +408,8 @@ fn test_parse_all_logs_private_big_sur() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur_private_enabled.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -411,7 +417,7 @@ fn test_parse_all_logs_private_big_sur() {
     let mut log_data_vec: Vec<LogData> = Vec::new();
     let exclude_missing = false;
     for logs in &log_data {
-        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &provider, &cache, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 887890);
@@ -441,7 +447,8 @@ fn test_parse_all_logs_private_with_public_mix_big_sur() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur_public_private_data_mix.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -450,7 +457,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur() {
     let exclude_missing = false;
 
     for logs in &log_data {
-        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &provider, &cache, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 1287628);
@@ -502,7 +509,8 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_single_file() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur_public_private_data_mix.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -513,7 +521,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_single_file() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 91567);
 
     let mut hex_count = 0;
@@ -547,7 +555,8 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_special_file() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur_public_private_data_mix.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -558,7 +567,7 @@ fn test_parse_all_logs_private_with_public_mix_big_sur_special_file() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 2238);
 
     let mut statedump = 0;
@@ -593,7 +602,8 @@ fn test_big_sur_missing_oversize_strings() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -605,7 +615,7 @@ fn test_big_sur_missing_oversize_strings() {
     test_path.pop();
 
     let exclude_missing = false;
-    let (data, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (data, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(data.len(), 101566);
 
     let mut missing_strings = 0;
@@ -624,7 +634,8 @@ fn test_big_sur_oversize_strings_in_another_file() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_big_sur.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
 
@@ -652,7 +663,7 @@ fn test_big_sur_oversize_strings_in_another_file() {
     results.oversize.append(&mut special_data.oversize);
 
     let exclude_missing = false;
-    let (data, _) = build_log(&results, &mut provider, &timesync_data, exclude_missing);
+    let (data, _) = build_log(&results, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(data.len(), 101566);
 
     let mut missing_strings = 0;

--- a/tests/big_sur_tests.rs
+++ b/tests/big_sur_tests.rs
@@ -9,13 +9,13 @@ use macos_unifiedlogs::{
     cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
-    traits::FileProvider,
+    traits::{FileProvider, SourceFile},
     unified_log::{EventType, LogData, LogType, UnifiedLogData},
 };
 use regex::Regex;
 use std::{fs::File, path::PathBuf};
 
-fn collect_logs(provider: &dyn FileProvider) -> Vec<UnifiedLogData> {
+fn collect_logs(provider: &impl FileProvider) -> Vec<UnifiedLogData> {
     provider
         .tracev3_files()
         .map(|mut file| {

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -7,7 +7,7 @@
 use std::{fs::File, path::PathBuf};
 
 use macos_unifiedlogs::{
-    cache::StringCache,
+    cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -54,7 +54,7 @@ fn test_build_log_high_sierra() {
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000001.tracev3");
@@ -96,7 +96,7 @@ fn test_build_log_complex_format_high_sierra() {
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000001.tracev3");
@@ -156,7 +156,7 @@ fn test_build_log_negative_number_high_sierra() {
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Special/0000000000000003.tracev3");
@@ -187,7 +187,7 @@ fn test_parse_all_logs_high_sierra() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
     let mut log_data_vec = Vec::new();

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -10,12 +10,12 @@ use macos_unifiedlogs::{
     cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
-    traits::FileProvider,
+    traits::{FileProvider, SourceFile},
     unified_log::{EventType, LogType, UnifiedLogData},
 };
 use regex::Regex;
 
-fn collect_logs(provider: &dyn FileProvider) -> Vec<UnifiedLogData> {
+fn collect_logs(provider: &impl FileProvider) -> Vec<UnifiedLogData> {
     provider
         .tracev3_files()
         .map(|mut file| {

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -7,6 +7,7 @@
 use std::{fs::File, path::PathBuf};
 
 use macos_unifiedlogs::{
+    cache::StringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -52,7 +53,8 @@ fn test_build_log_high_sierra() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000001.tracev3");
@@ -61,7 +63,7 @@ fn test_build_log_high_sierra() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 162402);
     assert_eq!(results[0].process, "/usr/libexec/opendirectoryd");
     assert_eq!(results[0].subsystem, "com.apple.opendirectoryd");
@@ -93,7 +95,8 @@ fn test_build_log_complex_format_high_sierra() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000001.tracev3");
@@ -102,7 +105,7 @@ fn test_build_log_complex_format_high_sierra() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 162402);
 
     for result in &results {
@@ -152,7 +155,8 @@ fn test_build_log_negative_number_high_sierra() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Special/0000000000000003.tracev3");
@@ -161,7 +165,7 @@ fn test_build_log_negative_number_high_sierra() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 12058);
 
     for result in &results {
@@ -182,14 +186,15 @@ fn test_build_log_negative_number_high_sierra() {
 fn test_parse_all_logs_high_sierra() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_high_sierra.logarchive");
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
     let mut log_data_vec = Vec::new();
 
     let exclude_missing = false;
     for logs in &log_data {
-        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &provider, &cache, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 569796);

--- a/tests/high_sierra_tests.rs
+++ b/tests/high_sierra_tests.rs
@@ -63,7 +63,13 @@ fn test_build_log_high_sierra() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 162402);
     assert_eq!(results[0].process, "/usr/libexec/opendirectoryd");
     assert_eq!(results[0].subsystem, "com.apple.opendirectoryd");
@@ -105,7 +111,13 @@ fn test_build_log_complex_format_high_sierra() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 162402);
 
     for result in &results {
@@ -165,7 +177,13 @@ fn test_build_log_negative_number_high_sierra() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 12058);
 
     for result in &results {

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -8,7 +8,7 @@
 use std::{fs::File, path::PathBuf};
 
 use macos_unifiedlogs::{
-    cache::StringCache,
+    cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -55,7 +55,7 @@ fn test_build_log_monterey() {
     test_path.push("tests/test_data/system_logs_monterey.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/000000000000000a.tracev3");
@@ -97,7 +97,7 @@ fn test_parse_all_logs_monterey() {
     test_path.push("tests/test_data/system_logs_monterey.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -64,7 +64,13 @@ fn test_build_log_monterey() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 322859);
     assert_eq!(results[0].process, "/kernel");
     assert_eq!(results[0].subsystem, "");

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -8,6 +8,7 @@
 use std::{fs::File, path::PathBuf};
 
 use macos_unifiedlogs::{
+    cache::StringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -53,7 +54,8 @@ fn test_build_log_monterey() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_monterey.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/000000000000000a.tracev3");
@@ -62,7 +64,7 @@ fn test_build_log_monterey() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 322859);
     assert_eq!(results[0].process, "/kernel");
     assert_eq!(results[0].subsystem, "");
@@ -94,7 +96,8 @@ fn test_parse_all_logs_monterey() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_monterey.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -104,7 +107,7 @@ fn test_parse_all_logs_monterey() {
     let message_re = Regex::new(r"^[\s]*%s\s*$").unwrap();
 
     for logs in &log_data {
-        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &provider, &cache, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 2397109);

--- a/tests/monterey_tests.rs
+++ b/tests/monterey_tests.rs
@@ -11,12 +11,12 @@ use macos_unifiedlogs::{
     cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
-    traits::FileProvider,
+    traits::{FileProvider, SourceFile},
     unified_log::{EventType, LogData, LogType, UnifiedLogData},
 };
 use regex::Regex;
 
-fn collect_logs(provider: &dyn FileProvider) -> Vec<UnifiedLogData> {
+fn collect_logs(provider: &impl FileProvider) -> Vec<UnifiedLogData> {
     provider
         .tracev3_files()
         .map(|mut file| {

--- a/tests/tahoe_tests.rs
+++ b/tests/tahoe_tests.rs
@@ -8,6 +8,7 @@
 use std::{fs::File, path::PathBuf};
 
 use macos_unifiedlogs::{
+    cache::StringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -53,7 +54,8 @@ fn test_build_log_tahoe() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_tahoe.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/000000000000000a.tracev3");
@@ -62,7 +64,7 @@ fn test_build_log_tahoe() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
     assert_eq!(results.len(), 305785);
 
     assert_eq!(
@@ -179,7 +181,8 @@ fn test_check_log_tahoe() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_tahoe.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000002.tracev3");
@@ -188,7 +191,7 @@ fn test_check_log_tahoe() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &mut provider, &timesync_data, exclude_missing);
+    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
 
     let mut invalid_shared_string_offsets = 0;
 
@@ -205,7 +208,8 @@ fn test_parse_all_logs_tahoe() {
     let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_path.push("tests/test_data/system_logs_tahoe.logarchive");
 
-    let mut provider = LogarchiveProvider::new(test_path.as_path());
+    let provider = LogarchiveProvider::new(test_path.as_path());
+    let cache = StringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);
@@ -214,7 +218,7 @@ fn test_parse_all_logs_tahoe() {
     let exclude_missing = false;
 
     for logs in &log_data {
-        let (mut data, _) = build_log(logs, &mut provider, &timesync_data, exclude_missing);
+        let (mut data, _) = build_log(logs, &provider, &cache, &timesync_data, exclude_missing);
         log_data_vec.append(&mut data);
     }
     assert_eq!(log_data_vec.len(), 4288584);

--- a/tests/tahoe_tests.rs
+++ b/tests/tahoe_tests.rs
@@ -8,7 +8,7 @@
 use std::{fs::File, path::PathBuf};
 
 use macos_unifiedlogs::{
-    cache::StringCache,
+    cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
     traits::FileProvider,
@@ -55,7 +55,7 @@ fn test_build_log_tahoe() {
     test_path.push("tests/test_data/system_logs_tahoe.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/000000000000000a.tracev3");
@@ -182,7 +182,7 @@ fn test_check_log_tahoe() {
     test_path.push("tests/test_data/system_logs_tahoe.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
     let timesync_data = collect_timesync(&provider).unwrap();
 
     test_path.push("Persist/0000000000000002.tracev3");
@@ -209,7 +209,7 @@ fn test_parse_all_logs_tahoe() {
     test_path.push("tests/test_data/system_logs_tahoe.logarchive");
 
     let provider = LogarchiveProvider::new(test_path.as_path());
-    let cache = StringCache::default();
+    let cache = MemoryStringCache::default();
 
     let timesync_data = collect_timesync(&provider).unwrap();
     let log_data = collect_logs(&provider);

--- a/tests/tahoe_tests.rs
+++ b/tests/tahoe_tests.rs
@@ -11,11 +11,11 @@ use macos_unifiedlogs::{
     cache::MemoryStringCache,
     filesystem::LogarchiveProvider,
     parser::{build_log, collect_timesync, parse_log},
-    traits::FileProvider,
+    traits::{FileProvider, SourceFile},
     unified_log::{EventType, LogData, LogType, UnifiedLogData},
 };
 
-fn collect_logs(provider: &dyn FileProvider) -> Vec<UnifiedLogData> {
+fn collect_logs(provider: &impl FileProvider) -> Vec<UnifiedLogData> {
     provider
         .tracev3_files()
         .map(|mut file| {

--- a/tests/tahoe_tests.rs
+++ b/tests/tahoe_tests.rs
@@ -64,7 +64,13 @@ fn test_build_log_tahoe() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
     assert_eq!(results.len(), 305785);
 
     assert_eq!(
@@ -191,7 +197,13 @@ fn test_check_log_tahoe() {
     let log_data = parse_log(handle, test_path.to_str().unwrap()).unwrap();
 
     let exclude_missing = false;
-    let (results, _) = build_log(&log_data, &provider, &cache, &timesync_data, exclude_missing);
+    let (results, _) = build_log(
+        &log_data,
+        &provider,
+        &cache,
+        &timesync_data,
+        exclude_missing,
+    );
 
     let mut invalid_shared_string_offsets = 0;
 


### PR DESCRIPTION
## Summary of changes

- Decouples cache from the `FileProvider` trait: this separates the concerns of caching string data from that of providing files for parsing. This allows consumers to implement their own `FileProvider` without having to worry about caching implementation, while also providing a sane default via `MemoryStringCache` with the option for consumers to implement their own cache their as well. 
- Converts to static dispatch via e.g. `impl FileProvider` instead of through boxing of trait objects. The reasoning behind this was that it's unlikely that callers would want to mix types when calling these functions.