### PR TITLE
Sort on DirEntry rather than SourceFile to avoid opening too many fd

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -5,7 +5,7 @@ use log::error;
 use std::fs::File;
 use std::io::{Error, ErrorKind, Read};
 use std::path::{Component, Path, PathBuf};
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
 pub struct LocalFile {
     reader: File,
@@ -105,25 +105,29 @@ impl From<&Path> for LogFileType {
 impl FileProvider for LiveSystemProvider {
     fn tracev3_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/diagnostics");
-        sort_files(
-            WalkDir::new(path)
-                .sort_by(|a, b| a.file_name().cmp(b.file_name()))
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
-        )
+
+        let entries = WalkDir::new(path)
+            .sort_by(|a, b| a.file_name().cmp(b.file_name()))
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 
     fn uuidtext_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/uuidtext");
-        sort_files(
-            WalkDir::new(path)
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
-        )
+
+        let entries = WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 
     fn read_uuidtext(&self, uuid: &str) -> Result<UUIDText, Error> {
@@ -210,26 +214,28 @@ impl FileProvider for LiveSystemProvider {
 
     fn dsc_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/uuidtext/dsc");
-        sort_files(WalkDir::new(path).into_iter().filter_map(|entry| {
-            if !matches!(
-                LogFileType::from(entry.as_ref().ok()?.path()),
-                LogFileType::Dsc
-            ) {
-                return None;
-            }
-            LocalFile::new(entry.ok()?.path()).ok()
-        }))
+
+        let entries = WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Dsc));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 
     fn timesync_files(&self) -> impl Iterator<Item = impl SourceFile> {
         let path = PathBuf::from("/private/var/db/diagnostics/timesync");
-        sort_files(
-            WalkDir::new(path)
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
-        )
+
+        let entries = WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 }
 
@@ -273,24 +279,26 @@ impl FileProvider for LogarchiveProvider {
     ///    }
     /// ```
     fn tracev3_files(&self) -> impl Iterator<Item = impl SourceFile> {
-        Box::new(
-            WalkDir::new(&self.base)
-                .sort_by(|a, b| a.file_name().cmp(b.file_name()))
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
-        )
+        let entries = WalkDir::new(&self.base)
+            .sort_by(|a, b| a.file_name().cmp(b.file_name()))
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::TraceV3));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 
     fn uuidtext_files(&self) -> impl Iterator<Item = impl SourceFile> {
-        sort_files(
-            WalkDir::new(&self.base)
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
-        )
+        let entries = WalkDir::new(&self.base)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::UUIDText));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 
     fn read_uuidtext(&self, uuid: &str) -> Result<UUIDText, Error> {
@@ -377,23 +385,25 @@ impl FileProvider for LogarchiveProvider {
     }
 
     fn dsc_files(&self) -> impl Iterator<Item = impl SourceFile> {
-        sort_files(
-            WalkDir::new(&self.base)
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Dsc))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
-        )
+        let entries = WalkDir::new(&self.base)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Dsc));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 
     fn timesync_files(&self) -> impl Iterator<Item = impl SourceFile> {
-        sort_files(
-            WalkDir::new(&self.base)
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync))
-                .filter_map(|entry| LocalFile::new(entry.path()).ok()),
-        )
+        let entries = WalkDir::new(&self.base)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| matches!(LogFileType::from(entry.path()), LogFileType::Timesync));
+
+        sort_files(entries)
+            .into_iter()
+            .filter_map(|entry| LocalFile::new(entry.path()).ok())
     }
 }
 
@@ -401,12 +411,10 @@ impl FileProvider for LogarchiveProvider {
 /// in order to have deterministic output of the parser.
 /// Not having it would cause parsing differences across systems
 /// (macOS does not guarantee order of files returned by the filesystem).
-fn sort_files(
-    files: impl Iterator<Item = impl SourceFile>,
-) -> impl Iterator<Item = impl SourceFile> {
+fn sort_files(files: impl Iterator<Item = DirEntry>) -> Vec<DirEntry> {
     let mut files = files.collect::<Vec<_>>();
-    files.sort_by(|a, b| a.source_path().cmp(b.source_path()));
-    Box::new(files.into_iter())
+    files.sort_by(|a, b| a.path().cmp(b.path()));
+    files
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR reduces the number of file `open()` during unified logs parsing whilst keeping the same deterministic sorting functionality for logarchive files. 

I noticed issues when parsing logarchives on MacOS as its default `ulimit -n` value is low. 

The culprit was that we called `files.collect::<Vec<_>>` on elements of type `LocalFile`.

This resulted in many non useful `File::open()` calls.

The new implementation now sorts on DirEntry rather SourceFile to avoid opening too many fd.