### PR TITLE
Check for large decompression size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,23 @@ keywords = ["forensics", "macOS", "unifiedlog"]
 
 [dependencies]
 nom = "8.0.0"
-serde_json = "1.0.149"
-serde = { version = "1.0.228", features = ["derive"] }
-log = "0.4.29"
-lz4_flex = "0.13.0"
+serde_json = "1.0.151"
+serde = { version = "1.0.229", features = ["derive"] }
+log = "0.4.33"
+lz4_flex = "0.14.0"
 byteorder = "1.5.0"
-plist = "1.9.0"
-regex = "1.12.3"
-base64 = "0.22.1"
-chrono = "0.4.44"
+plist = "1.10.0"
+regex = "1.13.1"
+base64 = "0.23.0"
+chrono = "0.4.45"
 walkdir = "2.5.0"
 sunlight = "0.1.5"
 
 [dev-dependencies]
-chrono = "0.4.44"
+chrono = "0.4.45"
 criterion = "0.8.2"
-anyhow = "1.0.102"
-test-case = "3.3"
+anyhow = "1.0.104"
+test-case = "3.3.1"
 
 [[bench]]
 name = "high_sierra_benchmark"

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -389,7 +389,7 @@ impl FirehosePreamble {
             } else {
                 error!(
                     "[macos-unifiedlogs] Unknown Firehose item: {}",
-                    &item.item_type
+                    item.item_type
                 );
                 debug!("[macos-unifiedlogs] Firehose item data: {data:?}");
             }

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -2379,4 +2379,15 @@ mod tests {
         );
         assert_eq!(unified_log.simpledump[0].first_proc_id, 1);
     }
+
+    #[test]
+    fn test_large_decompression() {
+        let test = [
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255,
+        ];
+
+        let err = ChunksetChunk::parse_chunkset(&test).unwrap_err();
+        assert_eq!(err, nom::Err::Incomplete(nom::Needed::Unknown));
+    }
 }

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -43,6 +43,14 @@ impl ChunksetChunk {
         let (input, chunkset_sig) = le_u32(input)?;
         let (input, chunkset_uncompress_size) = le_u32(input)?;
 
+        let abnormal_size = 1024 * 1024 * 1024;
+        if chunkset_uncompress_size > abnormal_size {
+            error!(
+                "[macos-unifiedlogs] Large decompression size provided (1GB+): {chunkset_uncompress_size:?}. Possible data corruption"
+            );
+            return Err(nom::Err::Incomplete(Needed::Unknown));
+        }
+
         let bv41 = 825521762; // bv41 signature
         let bv41_uncompressed = 758412898; // bv41- signature
 
@@ -55,7 +63,7 @@ impl ChunksetChunk {
             return Ok((input, chunkset_chunk));
         }
 
-        // Compressed data signatue should be bv41
+        // Compressed data signature should be bv41
         if chunkset_sig != bv41 {
             error!(
                 "[macos-unifiedlogs] Incorrect compression signature expected bv41, got: {chunkset_sig:?}"

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -198,7 +198,7 @@ mod tests {
             evidence: String::from("0000000000000002.tracev3"),
         };
 
-        let mut cache = MemoryStringCache::default();
+        let cache = MemoryStringCache::default();
 
         let mut total = 0;
         for chunk in log_iterator {

--- a/src/message.rs
+++ b/src/message.rs
@@ -253,7 +253,7 @@ pub fn format_firehose_log_message(
             }
             None => error!(
                 "Failed to split log message ({log_message}) by printf formatter: {}",
-                &values.formatter
+                values.formatter
             ),
         }
     }


### PR DESCRIPTION
Attempts to fix #137 by adding a small check for large decompression sizes.

The max decompressed data size for tracev3 chunks is ~65KBs (based on test data).

This adds a small check for decompression size greater than 1GB. If a 1GB decompression size is encountered, the library returns an error and that chunk is skipped.