### PR TITLE
Implements LZBITMAP decompression & persona support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.22.1"
 chrono = "0.4.44"
 walkdir = "2.5.0"
 sunlight = "0.1.5"
+compression-rs = "0.2.4"
 
 [dev-dependencies]
 chrono = "0.4.44"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["unifiedlog_iterator"]
+resolver = "3"

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use crate::{preamble::LogPreamble, util::*};
-use log::error;
+use log::{error, info};
 use nom::{
     IResult, Parser,
     bytes::complete::take,
@@ -32,7 +32,8 @@ pub struct CatalogChunk {
     pub catalog_offset_sub_chunks: u16,
     pub number_sub_chunks: u16,
     /// unknown 6 bytes, padding? alignment?
-    pub unknown: Vec<u8>,
+    pub catalog_persona_offset: u16,
+    pub catalog_persona_count: u32,
     pub earliest_firehose_timestamp: u64,
     /// array of UUIDs in big endian
     pub catalog_uuids: Vec<String>,
@@ -95,7 +96,7 @@ pub struct CatalogSubchunk {
     pub start: u64,
     pub end: u64,
     pub uncompressed_size: u32,
-    /// Should always be LZ4 (value 0x100)
+    /// Should always be LZ4 (value 0x100) or LZBITMAP0 (value 0x700)
     pub compression_algorithm: u32,
     pub number_index: u32,
     /// indexes size = `number_index` * u16
@@ -115,7 +116,8 @@ impl CatalogChunk {
     /// Parse log Catalog data. The log Catalog contains metadata related to log entries such as Process info, Subsystem info, and the compressed log entries
     pub fn parse_catalog(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, preamble) = LogPreamble::parse(input)?;
-        let mut tup = (le_u16, le_u16, le_u16, le_u16, le_u16);
+        // info!("First chunk bytes: {:x?}", input);
+        let mut tup = (le_u16, le_u16, le_u16, le_u16, le_u16, le_u16, le_u32, le_u64);
         let (
             input,
             (
@@ -124,12 +126,18 @@ impl CatalogChunk {
                 number_process_information_entries,
                 catalog_offset_sub_chunks,
                 number_sub_chunks,
+                catalog_persona_offset,
+                catalog_persona_count,
+                earliest_firehose_timestamp
             ),
         ) = tup.parse(input)?;
 
-        const UNKNOWN_LENGTH: u8 = 6;
+        info!("strings_offset: {}, info_offset: {}, info_count: {}, subchunk_offset: {}, subchunk_number: {}, persona_offset: {}, persona_count: {}, earliest_firehose_timestamp: {}", catalog_subsystem_strings_offset, catalog_process_info_entries_offset, number_process_information_entries, catalog_offset_sub_chunks, number_sub_chunks, catalog_persona_offset, catalog_persona_count, earliest_firehose_timestamp);
+
+        /* const UNKNOWN_LENGTH: u8 = 6;
         let (input, unknown) = map(take(UNKNOWN_LENGTH), |v: &[u8]| v.to_vec()).parse(input)?;
-        let (input, earliest_firehose_timestamp) = le_u64(input)?;
+        info!("Unknown length: {:x?}", unknown); */
+        // let (input, earliest_firehose_timestamp) = le_u64(input)?;
 
         const UUID_LENGTH: usize = 16;
         let number_catalog_uuids = catalog_subsystem_strings_offset as usize / UUID_LENGTH;
@@ -141,10 +149,14 @@ impl CatalogChunk {
         )
         .parse(input)?;
 
+        // info!("Found Catalog UUIDs: {:?}", catalog_uuids.len());
+
         let subsystems_strings_length =
             catalog_process_info_entries_offset - catalog_subsystem_strings_offset;
         let (input, subsystem_strings_data) = take(subsystems_strings_length)(input)?;
         let catalog_subsystem_strings = subsystem_strings_data.to_vec();
+
+        // info!("Subsystem Strings: {:?}", catalog_subsystem_strings.len());
 
         let (input, catalog_process_info_entries_vec) = many_m_n(
             number_process_information_entries as usize,
@@ -152,6 +164,8 @@ impl CatalogChunk {
             |input| Self::parse_catalog_process_entry(input, &catalog_uuids),
         )
         .parse(input)?;
+
+        // info!("Found process info entries: {}", catalog_process_info_entries_vec.len());
 
         let mut catalog_process_info_entries = HashMap::new();
         for entry in catalog_process_info_entries_vec {
@@ -163,6 +177,20 @@ impl CatalogChunk {
                 entry,
             );
         }
+
+        // Consuming the persona bytes if there are any, they are between process info entries and sub chunks
+        let input = if catalog_persona_count > 0 && catalog_persona_offset > 0 {
+            let (input, _) = take(catalog_offset_sub_chunks - catalog_persona_offset)(input)?;
+            // TODO: Parse the persona bytes
+            // log raw-dump on macOS just shows
+            // ----- Catalog Persona Section (skipping) -----
+            // Persona section found with 2 entries - skipping for compatibility
+            input
+        } else {
+            input
+        };
+
+        // info!("Found proc info entries: {:?}", catalog_process_info_entries.len());
         let (input, catalog_subchunks) = many_m_n(
             number_sub_chunks as usize,
             number_sub_chunks as usize,
@@ -180,7 +208,8 @@ impl CatalogChunk {
                 number_process_information_entries,
                 catalog_offset_sub_chunks,
                 number_sub_chunks,
-                unknown,
+                catalog_persona_offset,
+                catalog_persona_count,
                 earliest_firehose_timestamp,
                 catalog_uuids,
                 catalog_subsystem_strings,
@@ -327,12 +356,17 @@ impl CatalogChunk {
 
     /// Parse the Catalog Subchunk metadata. This metadata is related to the compressed (typically) Chunkset data
     fn parse_catalog_subchunk(input: &[u8]) -> IResult<&[u8], CatalogSubchunk> {
+        // info!("[macos-unifiedlogs] Catalog subchunk: {:x?}", input);
+
         let mut tup = (le_u64, le_u64, le_u32, le_u32, le_u32);
-        let (input, (start, end, uncompressed_size, compression_algorithmn, number_index)) =
+        let (input, (start, end, uncompressed_size, compression_algorithm, number_index)) =
             tup.parse(input)?;
 
-        const LZ4_COMPRESSION: u32 = 256;
-        if compression_algorithmn != LZ4_COMPRESSION {
+        // info!("Start: {:x}, End: {:x}, Uncomp Sz: {:x}, Algo: {:x}, Num Index: {:x}", start, end, uncompressed_size, compression_algorithm, number_index);
+
+        const LZ4_COMPRESSION: u32 = 0x100;
+        const LZBITMAP0_COMPRESSION: u32 = 0x700;
+        if compression_algorithm != LZ4_COMPRESSION && compression_algorithm != LZBITMAP0_COMPRESSION {
             return Err(nom::Err::Error(make_error(input, ErrorKind::OneOf)));
         }
 
@@ -371,7 +405,7 @@ impl CatalogChunk {
                 start,
                 end,
                 uncompressed_size,
-                compression_algorithm: compression_algorithmn,
+                compression_algorithm,
                 number_index,
                 indexes,
                 number_string_offsets,
@@ -485,7 +519,8 @@ mod tests {
         assert_eq!(catalog_data.number_process_information_entries, 1);
         assert_eq!(catalog_data.catalog_offset_sub_chunks, 160);
         assert_eq!(catalog_data.number_sub_chunks, 7);
-        assert_eq!(catalog_data.unknown, [0, 0, 0, 0, 0, 0]);
+        assert_eq!(catalog_data.catalog_persona_offset, 0);
+        assert_eq!(catalog_data.catalog_persona_count, 0);
         assert_eq!(catalog_data.earliest_firehose_timestamp, 820223379547412);
         assert_eq!(
             catalog_data.catalog_uuids,

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -19,6 +19,7 @@ pub struct FirehoseActivity {
     pub sentinal: u32,      // always 0x80000000?
     pub pid: u64,           // if flag 0x0010
     pub activity_id_2: u32, // if flag 0x0001
+    pub persona_id: u32,    // if flag 0x0040
     pub sentinal_2: u32,    // always 0x80000000? only if flag 0x0001
     pub activity_id_3: u32, // if flag 0x0200
     pub sentinal_3: u32,    // always 0x80000000? only if flag 0x0200
@@ -69,6 +70,17 @@ impl FirehoseActivity {
             activity.activity_id_2 = firehose_activity_id;
             activity.sentinal_2 = firehose_sentinel;
             activity.flags.push(MessageFlags::HasCurrentAid);
+
+            input = firehose_input;
+        }
+
+        let has_persona = 0x40; // has_persona flag
+        if (firehose_flags & has_persona) != 0 {
+            debug!("[macos-unifiedlogs] Activity Firehose log chunk has_persona flag");
+            let (firehose_input, persona_id) = le_u32(input)?;
+
+            activity.persona_id = persona_id;
+            activity.flags.push(MessageFlags::HasPersona);
 
             input = firehose_input;
         }

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -90,6 +90,7 @@ pub struct FirehoseItemType {
 pub enum FirehoseItem {
     String,
     PrivateNumber,
+    SensitiveNumber,
     Number,
     PrivateString,
     Precision,
@@ -133,6 +134,7 @@ impl FirehosePreamble {
     /// Remaining data (if any) contains strings for the string item types
     const STRING_ITEM: [u8; 8] = [0x20, 0x22, 0x40, 0x42, 0x30, 0x31, 0x32, 0xf2];
     const PRIVATE_NUMBER: u8 = 0x1;
+    const SENSITIVE_NUMBER: u8 = 0x5;
     /// 0x81 and 0xf1 Added in macOS Sequioa
     const PRIVATE_STRINGS: [u8; 7] = [0x21, 0x25, 0x35, 0x31, 0x41, 0x81, 0xf1];
     const LOG_TYPES: [u8; 5] = [0x2, 0x6, 0x4, 0x7, 0x3];
@@ -287,9 +289,10 @@ impl FirehosePreamble {
         let number_item_type = [0x0, 0x2];
         // Dynamic precision item types?
         let precision_items = [0x10, 0x12];
-        //  Likely realted to private string. Seen only "<private>" values
+        // Likely related to private string. Seen only "<private>" values
         // 0x85 and 0x5 added in macOS Sequioa
-        let sensitive_items = [0x5, 0x45, 0x85];
+        // 0x5 is a sensitive number, e.g. %{sensitive}.7f, %{sensitive}.7f
+        let sensitive_items = [0x45, 0x85];
         let object_items = [0x40, 0x42];
 
         while item_count < firehose_number_items {
@@ -367,6 +370,12 @@ impl FirehosePreamble {
                 continue;
             }
 
+            if item.item_type == Self::SENSITIVE_NUMBER {
+                item.item = FirehoseItem::SensitiveNumber;
+                item.message_strings = String::from("<private>");
+                continue;
+            }
+
             if item.item_type == Self::PRIVATE_NUMBER {
                 continue;
             }
@@ -389,8 +398,6 @@ impl FirehosePreamble {
                 firehose_input = item_value_input;
                 item.message_strings = message_string;
             } else {
-                // debug!("[macos-unifiedlogs] Firehose item data: {data:?}");
-                // fs::write(format!("firehose-items-{}.bin", item_count), data).unwrap();
                 panic!(
                     "[macos-unifiedlogs] Unknown Firehose item: {}",
                     &item.item_type
@@ -409,6 +416,7 @@ impl FirehosePreamble {
     ) -> nom::IResult<&'a [u8], ()> {
         let private_strings: Vec<u8> = vec![0x21, 0x25, 0x41, 0x35, 0x31, 0x81, 0xf1];
         let private_number = 0x1;
+        let sensitive_number = 0x5;
 
         let mut private_string_start = data;
         // Go through all firehose items, for each private item entry get the private value
@@ -456,6 +464,21 @@ impl FirehosePreamble {
                         private_string_start,
                         firehose_info.item_size,
                     )?;
+                    private_string_start = private_data;
+                    firehose_info.message_strings = format!("{private_string}");
+                }
+            } else if firehose_info.item_type == sensitive_number {
+                let private_number = 0x8000;
+                if firehose_info.item_size == private_number {
+                    firehose_info.message_strings = String::from("<private>")
+                } else {
+                    // info!("Sensitive Number: Noming {}", firehose_info.item_size);
+                    let (private_data, private_string) = FirehosePreamble::parse_item_number(
+                        private_string_start,
+                        firehose_info.item_size,
+                    )?;
+                    // info!("Got {}", private_string);
+
                     private_string_start = private_data;
                     firehose_info.message_strings = format!("{private_string}");
                 }

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -637,7 +637,7 @@ impl FirehosePreamble {
             }
         };
         let (mut input, _) = take(padding_data)(input)?;
-        if (padding_data as usize) > taken_data.len() {
+        if padding_data > taken_data.len() {
             input = remaining_data;
         }
 

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -5,6 +5,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
+use std::fs;
 use crate::chunks::firehose::activity::FirehoseActivity;
 use crate::chunks::firehose::loss::FirehoseLoss;
 use crate::chunks::firehose::nonactivity::FirehoseNonActivity;
@@ -13,7 +14,7 @@ use crate::chunks::firehose::trace::FirehoseTrace;
 use crate::util::{
     encode_standard, extract_string_size, padding_size_8, padding_size_four, u64_to_usize,
 };
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use nom::Parser;
 use nom::bytes::complete::take_while;
 use nom::combinator::map;
@@ -118,6 +119,7 @@ pub enum MessageFlags {
     HasPrivateData,
     HasOversize,
     HasSubsystem,
+    HasPersona,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -281,6 +283,9 @@ impl FirehosePreamble {
         let mut firehose_input = data;
         let mut firehose_item_data = FirehoseItemData::default();
 
+        // TODO: Unknown items
+        // 128, 98
+
         // Firehose number item values
         let number_item_type = [0x0, 0x2];
         // Dynamic precision item types?
@@ -291,7 +296,7 @@ impl FirehosePreamble {
         let object_items = [0x40, 0x42];
 
         while item_count < firehose_number_items {
-            // Get non-number values first since the values are at the end of the of the log (chunk) entry data
+            // Get non-number values first since the values are at the end of the log (chunk) entry data
             let (item_value_input, mut item) =
                 FirehosePreamble::get_firehose_items(firehose_input)?;
             firehose_input = item_value_input;
@@ -387,11 +392,12 @@ impl FirehosePreamble {
                 firehose_input = item_value_input;
                 item.message_strings = message_string;
             } else {
-                error!(
+                // debug!("[macos-unifiedlogs] Firehose item data: {data:?}");
+                // fs::write(format!("firehose-items-{}.bin", item_count), data).unwrap();
+                panic!(
                     "[macos-unifiedlogs] Unknown Firehose item: {}",
                     &item.item_type
                 );
-                debug!("[macos-unifiedlogs] Firehose item data: {data:?}");
             }
         }
 
@@ -464,6 +470,8 @@ impl FirehosePreamble {
     /// Parse all the different types of Firehose data (activity, non-activity, loss, trace, signpost)
     fn parse_firehose(data: &[u8]) -> nom::IResult<&[u8], Firehose> {
         let mut firehose_results = Firehose::default();
+
+        // fs::write("firehose.bin", data).unwrap();
 
         let (input, log_activity_type) = le_u8(data)?;
         let (input, log_type) = le_u8(input)?;

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -5,7 +5,6 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use std::fs;
 use crate::chunks::firehose::activity::FirehoseActivity;
 use crate::chunks::firehose::loss::FirehoseLoss;
 use crate::chunks::firehose::nonactivity::FirehoseNonActivity;
@@ -144,6 +143,8 @@ impl FirehosePreamble {
     ) -> nom::IResult<&[u8], FirehosePreamble> {
         let mut firehose_data = FirehosePreamble::default();
 
+        // fs::write("firehose-preamble.bin", firehose_input_data).unwrap();
+
         let (input, chunk_tag) = le_u32(firehose_input_data)?;
         let (input, chunk_sub_tag) = le_u32(input)?;
         let (input, chunk_data_size) = le_u64(input)?;
@@ -159,6 +160,8 @@ impl FirehosePreamble {
         let (input, unknown2) = le_u16(input)?;
         let (input, unknown3) = le_u16(input)?;
         let (log_data, base_continous_time) = le_u64(input)?;
+
+        // info!("Parsing firehose chunk with base: {base_continous_time}");
 
         firehose_data.chunk_tag = chunk_tag;
         firehose_data.chunk_sub_tag = chunk_sub_tag;
@@ -181,6 +184,8 @@ impl FirehosePreamble {
         let (mut input, mut public_data) =
             take(public_data_size - public_data_size_offset)(log_data)?;
 
+        // info!("Got initial chunk size public_data={} and input={}", public_data.len(), input.len());
+
         // Go through all the public data associated with log Firehose entry
         while !public_data.is_empty() {
             let (firehose_input, firehose_public_data) =
@@ -201,6 +206,7 @@ impl FirehosePreamble {
                         let leftover_data = input.len() - private_data_offset as usize;
                         let (private_data, _) = take(leftover_data)(input)?;
                         input = private_data;
+                        // info!("# Threw away leftover data: {} - {}", leftover_data, wow.len());
                     } else {
                         // If log data and public data are the same size. Use private data offset to calculate the private data
                         if log_data.len() == (public_data_size - public_data_size_offset) as usize {
@@ -208,6 +214,7 @@ impl FirehosePreamble {
                                 (private_data_virtual_offset - public_data_size_offset) as usize
                                     - public_data.len(),
                             )(log_data)?;
+                            // info!("# log data == public data: {}", trash.len());
                             input = private_input_data;
                         } else {
                             // If we have private data, then any leftover public data is actually prepended to the private data
@@ -224,10 +231,13 @@ impl FirehosePreamble {
                                 00000030: 2e 66 2e 69 70 36 2e 61 72 70 61 20 6e 5f 6e 61 .f.ip6.arpa n_na
                                 00000040: 6d 65 73 65 72 76 65 72 20 30 00 43 6f 6e 66 69 meserver 0.Confi
                             */
+                            // TODO: We're still missing FOUR BYTES HERE
+                            // Too much data passed as firehose data?
                             let (private_input_data, _) = take(
                                 (public_data_size - public_data_size_offset) as usize
                                     - public_data.len(),
                             )(log_data)?;
+                            // info!("# public data + private data: public_data_size={} - public_data_size_offset={} - public_data={} -> {}", public_data_size, public_data_size_offset, public_data.len(), private_input_data.len());
                             input = private_input_data;
                         }
                     }
@@ -435,6 +445,7 @@ impl FirehosePreamble {
                     || firehose_info.item_type == private_strings[4]
                 {
                     if private_string_start.len() < firehose_info.item_size as usize {
+                        info!("Private String B64 Smol: Noming {}", private_string_start.len());
                         let (private_data, pointer_object) =
                             take(private_string_start.len())(private_string_start)?;
                         private_string_start = private_data;
@@ -443,6 +454,7 @@ impl FirehosePreamble {
                         continue;
                     }
 
+                    info!("Private String B64: Noming {}", firehose_info.item_size);
                     let (private_data, pointer_object) =
                         take(firehose_info.item_size)(private_string_start)?;
                     private_string_start = private_data;
@@ -472,6 +484,7 @@ impl FirehosePreamble {
                         private_string_start,
                         u64::from(firehose_info.item_size),
                     )?;
+                    info!("Got {}", private_string);
 
                     private_string_start = private_data;
                     firehose_info.message_strings = private_string;
@@ -482,10 +495,13 @@ impl FirehosePreamble {
                 if firehose_info.item_size == private_number {
                     firehose_info.message_strings = String::from("<private>")
                 } else {
+                    info!("Private Number: Noming {}", firehose_info.item_size);
                     let (private_data, private_string) = FirehosePreamble::parse_item_number(
                         private_string_start,
                         firehose_info.item_size,
                     )?;
+                    info!("Got {}", private_string);
+
                     private_string_start = private_data;
                     firehose_info.message_strings = format!("{private_string}");
                 }
@@ -607,6 +623,7 @@ impl FirehosePreamble {
         // Nom any zero padding
         let (remaining_data, taken_data) = take_while(|b: u8| b == 0)(input)?;
 
+        info!("firehose preamble noomed {} padding bytes", taken_data.len());
         // Verify we did not nom into remnant/junk data
         let padding_data = padding_size_8(data_size.into());
         let padding_data = match u64_to_usize(padding_data) {

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -241,18 +241,27 @@ impl FirehosePreamble {
         }
 
         // If there is private data, go through and update any logs that have private data items
-        if private_data_virtual_offset != 0x1000 {
+        let private_data_size = 0x1000 - private_data_virtual_offset;
+        if private_data_size > 0 {
             debug!("[macos-unifiedlogs] Parsing Private Firehose Data");
-            // Nom any padding
-            let (mut private_input, _) = take_while(|b: u8| b == 0)(input)?;
 
-            // if we nom the rest of the data (all zeros) then the private data is actually zeros
-            // Or if the firehose data is collapsed, then there was no padding
-            if private_input.is_empty() || firehose_data.collapsed == 1 {
-                private_input = input;
+            // 0x20 the additional tracev3 header (chunk_tag, ...) has a size of 0x20 bytes.
+            // The firehose header starts with
+            let private_input = if firehose_data.collapsed > 0 {
+                let (private_input, _) = take(0x20 + firehose_data.public_data_size)(firehose_input_data)?;
+                private_input
+            } else {
+                let (private_input, _) = take(0x20 + firehose_data.private_data_virtual_offset)(firehose_input_data)?;
+                private_input
+            };
+
+            // info!("Got {} bytes of private data, wanted at least", private_input.len(), private_data_size);
+            if private_input.len() < private_data_size as usize {
+                warn!("Expected {} bytes of private data, but only got {}", private_data_size, input.len());
             }
 
             for data in &mut firehose_data.public_data {
+                // info!("= Parsing Public Firehose Data: {:x}", data.thread_id);
                 // Only non-activity firehose entries appears to have private strings
                 if data.firehose_non_activity.private_strings_size == 0 {
                     continue;
@@ -261,6 +270,7 @@ impl FirehosePreamble {
                 let string_offset =
                     data.firehose_non_activity.private_strings_offset - private_data_virtual_offset;
                 let (private_string_start, _) = take(string_offset)(private_input)?;
+                // info!("Nom {} string offset bytes ({} - {})", string_offset, data.firehose_non_activity.private_strings_offset, private_data_virtual_offset);
                 let _ =
                     FirehosePreamble::parse_private_data(private_string_start, &mut data.message);
             }

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -283,9 +283,6 @@ impl FirehosePreamble {
         let mut firehose_input = data;
         let mut firehose_item_data = FirehoseItemData::default();
 
-        // TODO: Unknown items
-        // 128, 98
-
         // Firehose number item values
         let number_item_type = [0x0, 0x2];
         // Dynamic precision item types?

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -11,9 +11,7 @@ use crate::chunks::firehose::loss::FirehoseLoss;
 use crate::chunks::firehose::nonactivity::FirehoseNonActivity;
 use crate::chunks::firehose::signpost::FirehoseSignpost;
 use crate::chunks::firehose::trace::FirehoseTrace;
-use crate::util::{
-    encode_standard, extract_string_size, padding_size_8, padding_size_four, u64_to_usize,
-};
+use crate::util::{encode_standard, extract_string_max_size, extract_string_size, padding_size_8, padding_size_four, u64_to_usize};
 use log::{debug, error, info, warn};
 use nom::Parser;
 use nom::bytes::complete::take_while;
@@ -456,7 +454,21 @@ impl FirehosePreamble {
                 if firehose_info.item_size == null_private {
                     firehose_info.message_strings = String::from("<private>");
                 } else {
-                    let (private_data, private_string) = extract_string_size(
+                    // TODO: message_size == 33748 -> no limit?
+                    info!("String: Noming {}", firehose_info.item_size);
+                    /* let (private_data, private_string) = if firehose_info.item_type == 0x21 {
+                        extract_string_max_size(
+                            private_string_start,
+                            u64::from(firehose_info.item_size),
+                        )?
+                    } else {
+                        extract_string_size(
+                            private_string_start,
+                            u64::from(firehose_info.item_size),
+                        )?
+                    }; */
+                    // seen null-terminated strings for 0x21 (private strings) and 0x41 (private objects b64 encoded strings)
+                    let (private_data, private_string) = extract_string_max_size(
                         private_string_start,
                         u64::from(firehose_info.item_size),
                     )?;

--- a/src/chunks/firehose/message.rs
+++ b/src/chunks/firehose/message.rs
@@ -717,7 +717,7 @@ impl MessageData {
         provider: &impl FileProvider,
         cache: &impl StringCache,
     ) -> nom::IResult<&'static [u8], String> {
-        // An UUID of all zeros is possilbe in the Catalog, if this happens there is no process path
+        // A UUID of all zeros is possible in the Catalog, if this happens there is no process path
         if main_uuid == "00000000000000000000000000000000" {
             info!("[macos-unifiedlogs] Got UUID of all zeros fom Catalog");
             return Ok((&[], String::new()));

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -17,6 +17,7 @@ use nom::number::complete::{le_u8, le_u16, le_u32};
 pub struct FirehoseNonActivity {
     pub activity_id: u32,            // if flag 0x0001
     pub sentinal: u32,               // always 0x80000000? if flag 0x0001
+    pub persona_id: u32,             // if flag 0x0040
     pub private_strings_offset: u16, // if flag 0x0100
     pub private_strings_size: u16,   // if flag 0x0100
     pub message_string_ref: u32,     // if flag 0x0008
@@ -47,6 +48,17 @@ impl FirehoseNonActivity {
             non_activity.activity_id = firehose_activity_id;
             non_activity.sentinal = firehose_unknown_sentinel;
             non_activity.flags.push(MessageFlags::HasCurrentAid);
+            input = firehose_input;
+        }
+
+        let has_persona = 0x40; // has_persona flag
+        if (firehose_flags & has_persona) != 0 {
+            debug!("[macos-unifiedlogs] Non-Activity Firehose log chunk has_persona flag");
+            let (firehose_input, persona_id) = le_u32(input)?;
+
+            non_activity.persona_id = persona_id;
+            non_activity.flags.push(MessageFlags::HasPersona);
+
             input = firehose_input;
         }
 

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -18,6 +18,7 @@ pub struct FirehoseSignpost {
     pub pc_id: u32, // Appears to be used to calculate string offset for firehose events with Absolute flag
     pub activity_id: u32,
     pub sentinel: u32,
+    pub persona_id: u32,             // if flag 0x0040
     pub subsystem: u16,
     pub signpost_id: u64,
     pub signpost_name: u32,
@@ -49,6 +50,17 @@ impl FirehoseSignpost {
             firehose_signpost.sentinel = firehose_sentinel;
             input = firehose_input;
             firehose_signpost.flags.push(MessageFlags::HasCurrentAid);
+        }
+
+        let has_persona = 0x40; // has_persona flag
+        if (firehose_flags & has_persona) != 0 {
+            debug!("[macos-unifiedlogs] Signpost Firehose log chunk has_persona flag");
+            let (firehose_input, persona_id) = le_u32(input)?;
+
+            firehose_signpost.persona_id = persona_id;
+            firehose_signpost.flags.push(MessageFlags::HasPersona);
+
+            input = firehose_input;
         }
 
         let private_string_range = 0x100; // has_private_data flag

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -5,14 +5,11 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use log::{error, warn};
-use lz4_flex::decompress;
-use nom::{
-    Needed,
-    bytes::complete::{take, take_while},
-    number::complete::{le_u32, le_u64},
-};
-
+use std::fs;
+use compression::Algorithm;
+use log::{error, info, warn};
+use nom::{bytes::complete::{take, take_while}, number::complete::{le_u32, le_u64}, Needed, Parser};
+use nom::combinator::peek;
 use crate::chunks::simpledump::SimpleDump;
 use crate::chunks::statedump::Statedump;
 use crate::{chunks::firehose::firehose_log::FirehosePreamble, util::u64_to_usize};
@@ -27,7 +24,7 @@ pub struct ChunksetChunk {
     pub chunk_data_size: u64,
     pub signature: u32, // should be "bv41"
     pub uncompress_size: u32,
-    pub block_size: u32,
+    pub block_size: Option<u32>,
     pub decompressed_data: Vec<u8>,
     pub footer: u32, // should be "bv4$"
 }
@@ -40,14 +37,20 @@ impl ChunksetChunk {
         let (input, chunkset_chunk_tag) = le_u32(data)?;
         let (input, chunkset_chunk_sub_tag) = le_u32(input)?;
         let (input, chunkset_chunk_data_size) = le_u64(input)?;
-        let (input, chunkset_sig) = le_u32(input)?;
-        let (input, chunkset_uncompress_size) = le_u32(input)?;
+        // info!("next bytes = {:x?}", input.get(0..4));
+
+        // do not consume
+        let (input, chunkset_sig) = peek(le_u32).parse(input)?;
 
         let bv41 = 825521762; // bv41 signature
         let bv41_uncompressed = 758412898; // bv41- signature
+        let zbmc = 206389850; // ZBM\x0C signature
 
         // Data is already decompressed (Observed in tracev3 files in /var/db/diagnostics/Special)
         if chunkset_sig == bv41_uncompressed {
+            // Consume compression signature
+            let (input, _) = le_u32(input)?;
+            let (input, chunkset_uncompress_size) = le_u32(input)?;
             let (input, uncompressed_data) = take(chunkset_uncompress_size)(input)?;
             chunkset_chunk.decompressed_data = uncompressed_data.to_vec();
             let (input, chunkset_footer) = le_u32(input)?;
@@ -56,37 +59,68 @@ impl ChunksetChunk {
         }
 
         // Compressed data signatue should be bv41
-        if chunkset_sig != bv41 {
+        if chunkset_sig != bv41 && chunkset_sig != zbmc {
             error!(
-                "[macos-unifiedlogs] Incorrect compression signature expected bv41, got: {chunkset_sig:?}"
+                "[macos-unifiedlogs] Incorrect compression signature expected bv41 or zbm\\x0c, got: {chunkset_sig:?}"
             );
             return Err(nom::Err::Incomplete(Needed::Unknown));
         }
 
-        let (input, chunkset_block_size) = le_u32(input)?;
+        info!("[macos-unifiedlogs] Chunkset: tag {:x}, sub tag {:x}, data size {}, signature {}", chunkset_chunk_tag, chunkset_chunk_sub_tag, chunkset_chunk_data_size, chunkset_sig);
 
         chunkset_chunk.chunk_tag = chunkset_chunk_tag;
         chunkset_chunk.chunk_sub_tag = chunkset_chunk_sub_tag;
         chunkset_chunk.chunk_data_size = chunkset_chunk_data_size;
         chunkset_chunk.signature = chunkset_sig;
-        chunkset_chunk.uncompress_size = chunkset_uncompress_size;
-        chunkset_chunk.block_size = chunkset_block_size;
 
-        let (input, compressed_data) = take(chunkset_block_size)(input)?;
-        let decompress_data_results =
-            decompress(compressed_data, chunkset_uncompress_size as usize);
+        // TODO: Use of compression metadata of sub chunk
+        // TODO: Speed-up idea for macOS platforms -> use native things -> but is that really faster?
+        let (input, decompress_data_results): (&[u8], Result<Vec<u8>, String>) = if chunkset_sig == bv41 {
+            // Consume compression signature
+            let (input, _) = le_u32(input)?;
+
+            // Only LZ4 has this concept of a block size
+            let (input, chunkset_uncompress_size) = le_u32(input)?;
+            let (input, chunkset_block_size) = le_u32(input)?;
+            chunkset_chunk.uncompress_size = chunkset_uncompress_size;
+            chunkset_chunk.block_size = Some(chunkset_block_size);
+
+            let (input, compressed_data) = take(chunkset_block_size)(input)?;
+            let res = lz4_flex::decompress(compressed_data, chunkset_uncompress_size as usize)
+                .map_err(|err| err.to_string());
+
+            (input, res)
+        } else if chunkset_sig == zbmc {
+            info!("[macos-unifiedlogs] Decoding Lzbitmap0 decompressed data");
+            let (input, compressed_data) = take(chunkset_chunk.chunk_data_size)(input)?;
+            let res = compression::decompress(compressed_data, Algorithm::Lzbitmap)
+                .map_err(|err| err.to_string());
+
+            (input, res)
+        } else {
+            return Err(nom::Err::Incomplete(Needed::Unknown));
+        };
 
         // The decompressed data contains multiple log entries
         match decompress_data_results {
-            Ok(decompress_data) => chunkset_chunk.decompressed_data = decompress_data,
+            Ok(decompress_data) => {
+                chunkset_chunk.uncompress_size = decompress_data.len() as u32;
+                chunkset_chunk.decompressed_data = decompress_data
+            },
             Err(err) => {
                 error!("[macos-unifiedlogs] Failed to decompress log data: {err:?}");
                 return Err(nom::Err::Incomplete(Needed::Unknown));
             }
         }
 
-        let (input, chunkset_footer) = le_u32(input)?;
-        chunkset_chunk.footer = chunkset_footer;
+        // Only LZ4 has a footer
+        let input = if chunkset_sig == bv41 {
+            let (input, chunkset_footer) = le_u32(input)?;
+            chunkset_chunk.footer = chunkset_footer;
+            input
+        } else {
+            input
+        };
 
         Ok((input, chunkset_chunk))
     }
@@ -98,6 +132,8 @@ impl ChunksetChunk {
     ) -> nom::IResult<&'a [u8], ()> {
         let mut input = data;
         let chunk_preamble_size = 16; // Include preamble size in total chunk size
+
+        // fs::write("chunkset.bin", input).unwrap();
 
         // Loop through decompressed chunkset data until all log entries (chunks) are read
         while !input.is_empty() {
@@ -1207,7 +1243,7 @@ mod tests {
         assert_eq!(chunkset.chunk_data_size, 21703);
         assert_eq!(chunkset.signature, 825521762); // "bv41"
         assert_eq!(chunkset.uncompress_size, 63560);
-        assert_eq!(chunkset.block_size, 21687);
+        assert_eq!(chunkset.block_size, Some(21687));
         assert_eq!(chunkset.decompressed_data.len(), 63560);
         assert_eq!(chunkset.footer, 607417954); // "bv4$"
     }
@@ -2183,7 +2219,7 @@ mod tests {
         assert_eq!(chunkset.chunk_data_size, 20758);
         assert_eq!(chunkset.signature, 825521762); // "bv41"
         assert_eq!(chunkset.uncompress_size, 62592);
-        assert_eq!(chunkset.block_size, 20742);
+        assert_eq!(chunkset.block_size, Some(20742));
         assert_eq!(chunkset.decompressed_data.len(), 62592);
         assert_eq!(chunkset.footer, 607417954); // "bv4$"
     }
@@ -2204,7 +2240,8 @@ mod tests {
                 number_process_information_entries: 0,
                 catalog_offset_sub_chunks: 0,
                 number_sub_chunks: 0,
-                unknown: Vec::new(),
+                catalog_persona_offset: 0,
+                catalog_persona_count: 0,
                 earliest_firehose_timestamp: 0,
                 catalog_uuids: Vec::new(),
                 catalog_subsystem_strings: Vec::new(),
@@ -2251,7 +2288,8 @@ mod tests {
                 number_process_information_entries: 0,
                 catalog_offset_sub_chunks: 0,
                 number_sub_chunks: 0,
-                unknown: Vec::new(),
+                catalog_persona_offset: 0,
+                catalog_persona_count: 0,
                 earliest_firehose_timestamp: 0,
                 catalog_uuids: Vec::new(),
                 catalog_subsystem_strings: Vec::new(),

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -5,7 +5,6 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use std::fs;
 use compression::Algorithm;
 use log::{error, info, warn};
 use nom::{bytes::complete::{take, take_while}, number::complete::{le_u32, le_u64}, Needed, Parser};

--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -564,8 +564,11 @@ pub(crate) fn dns_acceptable(data: &str) -> String {
 
 /// Translate DNS getaddrinfo log values
 pub(crate) fn dns_getaddrinfo_opts(data: &str) -> Result<&'static str, DecoderError<'_>> {
+    // TODO: data [52]: Unknown DNS getaddrinfo options
+    // 52 -> 0x34
     let message = match data {
         "0" => "0x0 {}",
+        "4" => "0x4 {in-app-browser}",
         "8" => "0x8 {use-failover}",
         "12" => "0xC {in-app-browser, use-failover}",
         "24" => "0x18 {use-failover, prohibit-encrypted-dns}",

--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -569,6 +569,7 @@ pub(crate) fn dns_getaddrinfo_opts(data: &str) -> Result<&'static str, DecoderEr
         "8" => "0x8 {use-failover}",
         "12" => "0xC {in-app-browser, use-failover}",
         "24" => "0x18 {use-failover, prohibit-encrypted-dns}",
+        "32" => "0x20 {use-cache-only}",
         _ => {
             return Err(DecoderError::Parse {
                 input: data.as_bytes(),

--- a/src/message.rs
+++ b/src/message.rs
@@ -15,6 +15,7 @@ use nom::Parser;
 use nom::branch::alt;
 use nom::bytes::complete::{is_a, is_not, take, take_until};
 use nom::character::complete::digit0;
+use nom::combinator::opt;
 use regex::Regex;
 
 struct FormatAndMessage {
@@ -289,7 +290,7 @@ fn parse_formatter<'a>(
 
     let number_item_type: Vec<u8> = vec![0x0, 0x1, 0x2];
 
-    // If the message formatter is expects a string/character and the message string is a number type
+    // If the message formatter expects a string/character and the message string is a number type
     // Try to convert to a character/string
     if formatter.to_lowercase().ends_with('c')
         && number_item_type.contains(&message_value[index].item_type)
@@ -363,7 +364,9 @@ fn parse_formatter<'a>(
 
     if formatter_message.starts_with('.') {
         let (input, _) = is_a(".")(formatter_message)?;
-        let (input, precision_data) = is_not("hljzZtqLdDiuUoOcCxXfFeEgGaASspPn%@")(input)?;
+        let (input, precision_data) = opt(is_not("hljzZtqLdDiuUoOcCxXfFeEgGaASspPn%@")).parse(input)?;
+        // Format strings such as "%.f" also exist, they are equivalent to "%.0f"
+        let precision_data = precision_data.unwrap_or_else(|| "0");
         if precision_data != "*" {
             let precision_results = precision_data.parse::<usize>();
             match precision_results {

--- a/src/preamble.rs
+++ b/src/preamble.rs
@@ -30,6 +30,7 @@ impl LogPreamble {
     pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         let mut tup = (le_u32, le_u32, le_u64);
         let (input, (chunk_tag, chunk_sub_tag, chunk_data_size)) = tup.parse(input)?;
+        // info!("Parsing log preamble: tag={:x}, subtag={:x}, size={}", chunk_tag, chunk_sub_tag, chunk_data_size);
         Ok((
             input,
             LogPreamble {

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -1207,7 +1207,8 @@ mod tests {
         assert_eq!(data.catalog.number_process_information_entries, 1);
         assert_eq!(data.catalog.catalog_offset_sub_chunks, 160);
         assert_eq!(data.catalog.number_sub_chunks, 7);
-        assert_eq!(data.catalog.unknown, [0, 0, 0, 0, 0, 0]);
+        assert_eq!(data.catalog.catalog_persona_offset, 0);
+        assert_eq!(data.catalog.catalog_persona_count, 0);
         assert_eq!(data.catalog.earliest_firehose_timestamp, 820223379547412);
         assert_eq!(
             data.catalog.catalog_uuids,

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -126,21 +126,21 @@ where
         (?:{[^}]+}?)                      # Get String formatters with %{<variable>}<variable> values. Ex: %{public}#llx with team ID %{public}@
         (?:[-+0#]{0,5})                   # optional flags
         (?:\d+|\*)?                       # width
-        (?:\.(?:\d+|\*))?                 # precision
+        (?:\.(?:\d+|\*)?)?                # precision (must also support %{public}1.f)
         (?:h|hh|l|ll|t|q|w|I|z|I32|I64)?  # size
-        [cCdiouxXeEfgGaAnpsSZPm@}]       # type
+        [cCdiouxXeEfgGaAnpsSZPm@}]        # type
 
         |                                 # OR get regular string formatters, ex: %s, %d
 
         (?:[-+0 #]{0,5})                  # optional flags
         (?:\d+|\*)?                       # width
-        (?:\.(?:\d+|\*))?                 # precision
+        (?:\.(?:\d+|\*)?)?                # precision
         (?:h|hh|l|ll|w|I|t|q|z|I32|I64)?  # size
         [cCdiouxXeEfgGaAnpsSZPm@%]        # type
         ))
         */
         let message_re_result = Regex::new(
-            r"(%(?:(?:\{[^}]+}?)(?:[-+0#]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*))?(?:h|hh|l|ll|w|I|z|t|q|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@}]|(?:[-+0 #]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*))?(?:h|hh|l||q|t|ll|w|I|z|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%]))",
+            r"(%(?:(?:\{[^}]+}?)(?:[-+0#]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*)?)?(?:h|hh|l|ll|w|I|z|t|q|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@}]|(?:[-+0 #]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*)?)?(?:h|hh|l||q|t|ll|w|I|z|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%]))",
         );
         let message_re = match message_re_result {
             Ok(message_re) => message_re,

--- a/src/util.rs
+++ b/src/util.rs
@@ -60,6 +60,7 @@ pub(crate) fn extract_string_size(data: &[u8], message_size: u64) -> nom::IResul
         match path_string {
             Ok(results) => return Ok((input, results.trim_end_matches(char::from(0)).to_string())),
             Err(err) => {
+                // warn!("Error parsing string of size {}: {:x?}", message_size, data);
                 error!("[macos-unifiedlogs] Failed to get extract specific string size: {err:?}")
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,10 +10,11 @@ use chrono::{SecondsFormat, TimeZone, Utc};
 use log::{error, warn};
 use nom::{
     Parser,
-    bytes::complete::{take, take_while},
+    bytes::complete::{take, take_while, take_while_m_n},
     combinator::opt,
     error::ErrorKind,
 };
+use std::cmp::min;
 use std::str::from_utf8;
 
 /// Returns the padding to consume in order to align to 8 bytes
@@ -86,6 +87,56 @@ pub(crate) fn extract_string_size(data: &[u8], message_size: u64) -> nom::IResul
 }
 
 const NULL_BYTE: u8 = 0;
+
+/// Extract a size from private Firehose string item entries either stopping at its maximum size or the first null termination we encounter.
+pub(crate) fn extract_string_max_size(data: &[u8], max_size: u64) -> nom::IResult<&[u8], String> {
+    const NULL_STRING: u64 = 0;
+    if max_size == NULL_STRING {
+        return Ok((data, String::from("(null)")));
+    }
+
+    // Get whole string message except end of string (0s)
+    let max_size = match u64_to_usize(max_size) {
+        Some(m) => m,
+        None => {
+            error!("[macos-unifiedlogs] u64 is bigger than system usize");
+            return Err(nom::Err::Error(nom::error::Error::new(
+                data,
+                nom::error::ErrorKind::TooLarge,
+            )));
+        }
+    };
+
+    // If our remaining data is smaller than the message string size just go until the end of the remaining data
+    // It's important that we stop at the NULL terminator as some private data item have an item_size larger than their actucal number of character.
+    let (input, path) =
+        take_while_m_n(0, min(data.len(), max_size), |i| i != NULL_BYTE)(data)?;
+
+    // Remove the null byte from the input
+    let input = if path.len() < max_size {
+        input.strip_prefix(&[NULL_BYTE]).unwrap_or(input)
+    } else {
+        input
+    };
+
+    // Convert bytes to UTF-8
+    match String::from_utf8(path.to_vec()) {
+        Ok(results) => {
+            let trimmed_string = results.trim_end_matches(char::from(NULL_BYTE));
+
+            // If the string is the private data is shorter than the item_size log raw-dump appends "<…>"
+            let trimmed_string = if path.len() < max_size {
+                format!("{}<…>", trimmed_string)
+            } else {
+                trimmed_string.to_string()
+            };
+
+            return Ok((input, trimmed_string));
+        }
+        Err(err) => error!("[macos-unifiedlogs] Failed to get specific string: {err:?}"),
+    }
+    Ok((input, String::from("Could not find path string")))
+}
 
 /// Extract an UTF8 string from a byte array, stops at `NULL_BYTE` or END OF STRING
 /// Consumes the end byte


### PR DESCRIPTION
An unfinished pull request to support logs from iOS 27 sysdiagnoses. Unified logs for iOS 27 use the LZBITMAP compression and add a new persona system. See #145.

This PR is not finished, still outputs a lot of errors, does not yet work on all platforms and contains a lot of debugging code. Nonetheless I think the core insights are already quite valuable. I'll improve the PR over the coming days and signal when its ready for review.

The current version of the pull request should work on macOS 26.