### PR TITLE
Rust based lzbitmap decompression support

### DIFF
--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -389,7 +389,7 @@ impl FirehosePreamble {
             } else {
                 error!(
                     "[macos-unifiedlogs] Unknown Firehose item: {}",
-                    &item.item_type
+                    item.item_type
                 );
                 debug!("[macos-unifiedlogs] Firehose item data: {data:?}");
             }

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -13,12 +13,12 @@ use nom::{
     number::complete::{le_u32, le_u64},
 };
 
-use crate::chunks::simpledump::SimpleDump;
 use crate::chunks::statedump::Statedump;
 use crate::{chunks::firehose::firehose_log::FirehosePreamble, util::u64_to_usize};
 use crate::{
     chunks::oversize::Oversize, preamble::LogPreamble, unified_log::UnifiedLogCatalogData,
 };
+use crate::{chunks::simpledump::SimpleDump, lzbitmap::lzbitmap_decompress};
 
 #[derive(Debug, Default)]
 pub struct ChunksetChunk {
@@ -39,8 +39,8 @@ impl ChunksetChunk {
 
         let (input, chunkset_chunk_tag) = le_u32(data)?;
         let (input, chunkset_chunk_sub_tag) = le_u32(input)?;
-        let (input, chunkset_chunk_data_size) = le_u64(input)?;
-        let (input, chunkset_sig) = le_u32(input)?;
+        let (chunk_input, chunkset_chunk_data_size) = le_u64(input)?;
+        let (input, chunkset_sig) = le_u32(chunk_input)?;
         let (input, chunkset_uncompress_size) = le_u32(input)?;
 
         let bv41 = 825521762; // bv41 signature
@@ -55,7 +55,21 @@ impl ChunksetChunk {
             return Ok((input, chunkset_chunk));
         }
 
-        // Compressed data signatue should be bv41
+        // Only two likely to exist
+        let lzbitmap_sigs = [206389850, 156058202, 223167066, 139280986];
+        if lzbitmap_sigs.contains(&chunkset_sig) {
+            let (input, decom_bytes) = lzbitmap_decompress(chunk_input)?;
+            // Always [6, 0, 0, 0, 0, 0]?
+            // Maybe its a version number?
+            let (input, chunkset_footer) = le_u32(input)?;
+
+            chunkset_chunk.decompressed_data = decom_bytes;
+            chunkset_chunk.footer = chunkset_footer;
+
+            return Ok((input, chunkset_chunk));
+        }
+
+        // Compressed data signature should be bv41
         if chunkset_sig != bv41 {
             error!(
                 "[macos-unifiedlogs] Incorrect compression signature expected bv41, got: {chunkset_sig:?}"
@@ -2370,5 +2384,55 @@ mod tests {
             "user/501/com.apple.mdworker.shared.0B000000-0000-0000-0000-000000000000 [4229]"
         );
         assert_eq!(unified_log.simpledump[0].first_proc_id, 1);
+    }
+
+    #[test]
+    fn test_parse_goldengate_chunkset() {
+        let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        test_path.push("tests/test_data/Chunkset Tests/goldengate_chunkset.raw");
+
+        let buffer = fs::read(test_path).unwrap();
+        let mut unified_log = UnifiedLogCatalogData {
+            catalog: CatalogChunk {
+                chunk_tag: 0,
+                chunk_sub_tag: 0,
+                chunk_data_size: 0,
+                catalog_subsystem_strings_offset: 0,
+                catalog_process_info_entries_offset: 0,
+                number_process_information_entries: 0,
+                catalog_offset_sub_chunks: 0,
+                number_sub_chunks: 0,
+                unknown: Vec::new(),
+                earliest_firehose_timestamp: 0,
+                catalog_uuids: Vec::new(),
+                catalog_subsystem_strings: Vec::new(),
+                catalog_process_info_entries: HashMap::new(),
+                catalog_subchunks: Vec::new(),
+            },
+            firehose: Vec::new(),
+            simpledump: Vec::new(),
+            statedump: Vec::new(),
+            oversize: Vec::new(),
+        };
+
+        let (_, _) = ChunksetChunk::parse_chunkset_data(&buffer, &mut unified_log).unwrap();
+        assert_eq!(unified_log.oversize.len(), 14);
+        assert_eq!(unified_log.firehose.len(), 8);
+
+        assert_eq!(unified_log.oversize[3].first_proc_id, 123);
+        assert_eq!(unified_log.oversize[3].second_proc_id, 335);
+        assert_eq!(unified_log.oversize[3].continuous_time, 8238750577);
+        assert_eq!(unified_log.oversize[3].public_data_size, 1082);
+        assert_eq!(unified_log.oversize[3].private_data_size, 0);
+
+        assert_eq!(
+            unified_log.firehose[1].public_data[0].message.item_info[0].message_strings,
+            "assetType:com.apple.MobileAsset.UAF.FM.Overrides | assetVersion:32025010.20251009.91600.100.1651,0 | assetSpecifier:com.apple.gm.safety_deny.output.photos_memories.user_query.generic | clientName:auto-asset-client | timeStart:2026-08-03 14:47:54 +0000 | timeEnd:2026-08-03 14:51:31 +0000 | totalBytes:21504 | result:Y"
+        );
+        assert_eq!(unified_log.firehose[3].base_continous_time, 0);
+        assert_eq!(unified_log.firehose[3].first_number_proc_id, 123);
+        assert_eq!(unified_log.firehose[3].second_number_proc_id, 335);
+        assert_eq!(unified_log.firehose[3].public_data_size, 4064);
+        assert_eq!(unified_log.firehose[3].private_data_virtual_offset, 4096);
     }
 }

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -2386,7 +2386,7 @@ mod tests {
         assert_eq!(unified_log.simpledump[0].first_proc_id, 1);
     }
 
-    #[test]
+    //#[test]
     fn test_parse_goldengate_chunkset() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/Chunkset Tests/goldengate_chunkset.raw");
@@ -2416,23 +2416,17 @@ mod tests {
         };
 
         let (_, _) = ChunksetChunk::parse_chunkset_data(&buffer, &mut unified_log).unwrap();
-        assert_eq!(unified_log.oversize.len(), 14);
-        assert_eq!(unified_log.firehose.len(), 8);
-
-        assert_eq!(unified_log.oversize[3].first_proc_id, 123);
-        assert_eq!(unified_log.oversize[3].second_proc_id, 335);
-        assert_eq!(unified_log.oversize[3].continuous_time, 8238750577);
-        assert_eq!(unified_log.oversize[3].public_data_size, 1082);
-        assert_eq!(unified_log.oversize[3].private_data_size, 0);
+        assert_eq!(unified_log.oversize.len(), 0);
+        assert_eq!(unified_log.firehose.len(), 4);
 
         assert_eq!(
-            unified_log.firehose[1].public_data[0].message.item_info[0].message_strings,
-            "assetType:com.apple.MobileAsset.UAF.FM.Overrides | assetVersion:32025010.20251009.91600.100.1651,0 | assetSpecifier:com.apple.gm.safety_deny.output.photos_memories.user_query.generic | clientName:auto-asset-client | timeStart:2026-08-03 14:47:54 +0000 | timeEnd:2026-08-03 14:51:31 +0000 | totalBytes:21504 | result:Y"
+            unified_log.firehose[2].public_data[0].message.item_info[0].message_strings,
+            "535313532480"
         );
-        assert_eq!(unified_log.firehose[3].base_continous_time, 0);
-        assert_eq!(unified_log.firehose[3].first_number_proc_id, 123);
-        assert_eq!(unified_log.firehose[3].second_number_proc_id, 335);
-        assert_eq!(unified_log.firehose[3].public_data_size, 4064);
-        assert_eq!(unified_log.firehose[3].private_data_virtual_offset, 4096);
+        assert_eq!(unified_log.firehose[2].base_continous_time, 0);
+        assert_eq!(unified_log.firehose[2].first_number_proc_id, 338);
+        assert_eq!(unified_log.firehose[2].second_number_proc_id, 979);
+        assert_eq!(unified_log.firehose[2].public_data_size, 2568);
+        assert_eq!(unified_log.firehose[2].private_data_virtual_offset, 4096);
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -198,7 +198,7 @@ mod tests {
             evidence: String::from("0000000000000002.tracev3"),
         };
 
-        let mut cache = MemoryStringCache::default();
+        let cache = MemoryStringCache::default();
 
         let mut total = 0;
         for chunk in log_iterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ mod error;
 pub mod filesystem;
 mod header;
 pub mod iterator;
+mod lzbitmap;
 /// Functions to assemble the log message
 mod message;
 /// Functions to extract and assemble log entries from the macOS Unified Log

--- a/src/lzbitmap.rs
+++ b/src/lzbitmap.rs
@@ -1,7 +1,6 @@
 /// Heavily influenced by <https://github.com/fox-it/dissect.util/blob/main/dissect/util/compression/lzbitmap.py> -- Apache license
 use log::{error, warn};
 use nom::{
-    Needed,
     bytes::complete::take,
     error::{Error, ErrorKind},
     number::complete::{le_u8, le_u16, le_u24},
@@ -15,7 +14,7 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
     let magic_signature = 5063258;
     if signature != magic_signature {
         error!("[macos-unifiedlogs] Unexpected signature for LZBITMAP {signature}. Wanted ZBM");
-        return Err(nom::Err::Incomplete(Needed::Unknown));
+        return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
     }
 
     let (mut input, flags) = le_u8(input)?;
@@ -46,7 +45,7 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
                 "[macos-unifiedlogs] Bad LZBITMAP chunk size: {compress_size} vs {}",
                 decom_size + chunk_header_size
             );
-            return Err(nom::Err::Incomplete(Needed::Unknown));
+            return Err(nom::Err::Failure(Error::new(input, ErrorKind::LengthValue)));
         }
 
         if decom_size == 0 {
@@ -57,7 +56,7 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
             error!(
                 "[macos-unifiedlogs] Chunk decompressed size is larger ({decom_size}) than expected max chunk size: {max_chunk}"
             );
-            return Err(nom::Err::Incomplete(Needed::Unknown));
+            return Err(nom::Err::Failure(Error::new(input, ErrorKind::LengthValue)));
         }
 
         // Data is not compressed. We can just append to our decompressed data
@@ -69,6 +68,9 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
         }
 
         // We have compressed data we need to decompress now
+        // Distance - Contains distance data needed determine how far back to look in the decompressed data
+        // Bitmap - Contains bitmap bits used to determine how to read and decompress the data. Bit 1 - read compressed data, bit 0 - copy decompressed data
+        // Token - Determines if distance or bitmap should be used
         let (remaining, mut distance_offset) = le_u24(remaining)?;
         let (remaining, mut bitmap_offset) = le_u24(remaining)?;
         let (_, token_offset) = le_u24(remaining)?;
@@ -81,7 +83,7 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
             error!(
                 "[macos-unifiedlogs] Bitmap size larger than compressed data size: {bitmap_size} vs {compress_size}"
             );
-            return Err(nom::Err::Incomplete(Needed::Unknown));
+            return Err(nom::Err::Failure(Error::new(input, ErrorKind::LengthValue)));
         }
         let (bits_data, _) = take(compress_size - bitmap_size)(compressed_data)?;
 
@@ -102,7 +104,7 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
             error!(
                 "[macos-unifiedlogs] Token offset {token_offset} larger than compressed data: {compress_size} bytes"
             );
-            return Err(nom::Err::Incomplete(Needed::Unknown));
+            return Err(nom::Err::Failure(Error::new(input, ErrorKind::LengthValue)));
         }
 
         let token_bytes =
@@ -111,16 +113,18 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
         let mut distance = 8;
 
         while decom_size > 0 {
-            let index = tokens.next().ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+            let index = tokens
+                .next()
+                .ok_or(nom::Err::Failure(Error::new(input, ErrorKind::Verify)))?;
 
             let repeat_token = if run_length_encoded_tokens {
                 if index == 0xf {
-                    return Err(nom::Err::Incomplete(Needed::Unknown));
+                    return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
                 }
 
                 match get_repeat_token(&mut tokens, decom_size as usize) {
                     Some(value) => value,
-                    None => return Err(nom::Err::Incomplete(Needed::Unknown)),
+                    None => return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify))),
                 }
             } else {
                 1
@@ -130,13 +134,13 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
                 let (mut bitmap, distance_bytes) = token_map
                     .get(index as usize)
                     .copied()
-                    .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                    .ok_or(nom::Err::Failure(Error::new(input, ErrorKind::Verify)))?;
 
                 // Indexes less than 3 use bitmap from bitmap bytes
                 if index < 3 {
                     bitmap = *compressed_data
                         .get(bitmap_offset as usize)
-                        .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                        .ok_or(nom::Err::Failure(Error::new(input, ErrorKind::Verify)))?;
                     bitmap_offset += 1;
                 }
 
@@ -146,27 +150,27 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
                         distance = usize::from(
                             *compressed_data
                                 .get(distance_offset as usize)
-                                .ok_or(nom::Err::Incomplete(Needed::Unknown))?,
+                                .ok_or(nom::Err::Failure(Error::new(input, ErrorKind::Verify)))?,
                         );
                         distance_offset += 1;
                     }
                     2 => {
                         let bytes = compressed_data
                             .get(distance_offset as usize..distance_offset as usize + 2)
-                            .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                            .ok_or(nom::Err::Failure(Error::new(input, ErrorKind::Verify)))?;
 
                         let (_, value) = le_u16(bytes)?;
                         distance = value as usize;
                         distance_offset += 2;
                     }
-                    _ => return Err(nom::Err::Incomplete(Needed::Unknown)),
+                    _ => return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify))),
                 }
 
                 for _ in 0..8 {
                     if bitmap & 1 != 0 {
                         let value = *compressed_data
                             .get(current_offset as usize)
-                            .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                            .ok_or(nom::Err::Failure(Error::new(input, ErrorKind::Verify)))?;
                         decom_buf.push(value);
                         current_offset += 1;
                     } else {
@@ -174,12 +178,12 @@ pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
                             error!(
                                 "[macos-unifiedlogs] Got distance 0 for checked_sub on decompressed data"
                             );
-                            return Err(nom::Err::Incomplete(Needed::Unknown));
+                            return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
                         }
                         let source_offset = decom_buf
                             .len()
                             .checked_sub(distance)
-                            .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                            .ok_or(nom::Err::Failure(Error::new(input, ErrorKind::Verify)))?;
                         let value = decom_buf[source_offset];
                         decom_buf.push(value);
                     }
@@ -256,7 +260,7 @@ mod tests {
     use crate::lzbitmap::lzbitmap_decompress;
     use std::{fs, path::PathBuf};
 
-    #[test]
+    // #[test]
     fn test_decompress_lzbitmap() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/lzbitmap/lzbitmap_zbm.raw");
@@ -264,8 +268,7 @@ mod tests {
         let buffer = fs::read(test_path).unwrap();
 
         let (_, results) = lzbitmap_decompress(&buffer).unwrap();
-        assert!(results.starts_with(&[2, 96, 0, 0, 0, 0, 0, 0, 25,]));
-
-        assert_eq!(results.len(), 62768);
+        assert!(results.starts_with(&[1, 96, 0, 0, 0, 0, 0, 0, 6, 16, 0, 0, 0, 0, 0, 0, 80, 2, 0]));
+        assert_eq!(results.len(), 65424);
     }
 }

--- a/src/lzbitmap.rs
+++ b/src/lzbitmap.rs
@@ -1,0 +1,271 @@
+/// Heavily influenced by <https://github.com/fox-it/dissect.util/blob/main/dissect/util/compression/lzbitmap.py> -- Apache license
+use log::{error, warn};
+use nom::{
+    Needed,
+    bytes::complete::take,
+    error::{Error, ErrorKind},
+    number::complete::{le_u8, le_u16, le_u24},
+};
+use std::iter::Peekable;
+
+/// Decompress lzbitmap data. Seen in Unified Logs starting in Golden Gate
+pub(crate) fn lzbitmap_decompress(data: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
+    let (input, signature) = le_u24(data)?;
+    // ZBM
+    let magic_signature = 5063258;
+    if signature != magic_signature {
+        error!("[macos-unifiedlogs] Unexpected signature for LZBITMAP {signature}. Wanted ZBM");
+        return Err(nom::Err::Incomplete(Needed::Unknown));
+    }
+
+    let (mut input, flags) = le_u8(input)?;
+
+    if !check_flags(flags) {
+        return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
+    }
+
+    let flag_large = 1;
+    let flag_no_run_length = 4;
+    let max_chunk = if flags & flag_large != 0 {
+        0x8000
+    } else {
+        0x4000
+    };
+
+    let run_length_encoded_tokens = flags & flag_no_run_length == 0;
+    let bitmaps_count = if run_length_encoded_tokens { 12 } else { 13 };
+    let mut decom_buf = Vec::new();
+
+    let chunk_header_size = 6;
+    while !input.is_empty() {
+        let (remaining, compress_size) = le_u24(input)?;
+        let (remaining, mut decom_size) = le_u24(remaining)?;
+
+        if compress_size > decom_size + chunk_header_size {
+            error!(
+                "[macos-unifiedlogs] Bad LZBITMAP chunk size: {compress_size} vs {}",
+                decom_size + chunk_header_size
+            );
+            return Err(nom::Err::Incomplete(Needed::Unknown));
+        }
+
+        if decom_size == 0 {
+            break;
+        }
+
+        if decom_size > max_chunk {
+            error!(
+                "[macos-unifiedlogs] Chunk decompressed size is larger ({decom_size}) than expected max chunk size: {max_chunk}"
+            );
+            return Err(nom::Err::Incomplete(Needed::Unknown));
+        }
+
+        // Data is not compressed. We can just append to our decompressed data
+        if compress_size == decom_size + chunk_header_size {
+            let (remaining, decom_data) = take(decom_size)(remaining)?;
+            decom_buf.extend_from_slice(decom_data);
+            input = remaining;
+            continue;
+        }
+
+        // We have compressed data we need to decompress now
+        let (remaining, mut distance_offset) = le_u24(remaining)?;
+        let (remaining, mut bitmap_offset) = le_u24(remaining)?;
+        let (_, token_offset) = le_u24(remaining)?;
+        let mut current_offset = 15;
+
+        // Compressed data includes the offsets we read above. We need to include it in the total compressed data
+        let (remaining, compressed_data) = take(compress_size)(input)?;
+        let bitmap_size = 17;
+        if bitmap_size > compress_size {
+            error!(
+                "[macos-unifiedlogs] Bitmap size larger than compressed data size: {bitmap_size} vs {compress_size}"
+            );
+            return Err(nom::Err::Incomplete(Needed::Unknown));
+        }
+        let (bits_data, _) = take(compress_size - bitmap_size)(compressed_data)?;
+
+        let mut token_map = vec![(0u8, 0u8), (0, 1), (0, 2)];
+
+        for i in 0..bitmaps_count {
+            let bit = i * 10;
+            let (_, bytes) = le_u16(&bits_data[bit / 8..])?;
+            let value = bytes >> (bit % 8);
+            token_map.push(((value & 0xff) as u8, ((value >> 8) & 3) as u8));
+        }
+
+        if distance_offset < 15
+            || distance_offset > bitmap_offset
+            || bitmap_offset > token_offset
+            || token_offset > compress_size - bitmap_size
+        {
+            error!(
+                "[macos-unifiedlogs] Token offset {token_offset} larger than compressed data: {compress_size} bytes"
+            );
+            return Err(nom::Err::Incomplete(Needed::Unknown));
+        }
+
+        let token_bytes =
+            &compressed_data[token_offset as usize..compressed_data.len() - bitmap_size as usize];
+        let mut tokens = get_tokens(token_bytes).peekable();
+        let mut distance = 8;
+
+        while decom_size > 0 {
+            let index = tokens.next().ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+
+            let repeat_token = if run_length_encoded_tokens {
+                if index == 0xf {
+                    return Err(nom::Err::Incomplete(Needed::Unknown));
+                }
+
+                match get_repeat_token(&mut tokens, decom_size as usize) {
+                    Some(value) => value,
+                    None => return Err(nom::Err::Incomplete(Needed::Unknown)),
+                }
+            } else {
+                1
+            };
+
+            for _ in 0..repeat_token {
+                let (mut bitmap, distance_bytes) = token_map
+                    .get(index as usize)
+                    .copied()
+                    .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+
+                // Indexes less than 3 use bitmap from bitmap bytes
+                if index < 3 {
+                    bitmap = *compressed_data
+                        .get(bitmap_offset as usize)
+                        .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                    bitmap_offset += 1;
+                }
+
+                match distance_bytes {
+                    0 => {}
+                    1 => {
+                        distance = usize::from(
+                            *compressed_data
+                                .get(distance_offset as usize)
+                                .ok_or(nom::Err::Incomplete(Needed::Unknown))?,
+                        );
+                        distance_offset += 1;
+                    }
+                    2 => {
+                        let bytes = compressed_data
+                            .get(distance_offset as usize..distance_offset as usize + 2)
+                            .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+
+                        let (_, value) = le_u16(bytes)?;
+                        distance = value as usize;
+                        distance_offset += 2;
+                    }
+                    _ => return Err(nom::Err::Incomplete(Needed::Unknown)),
+                }
+
+                for _ in 0..8 {
+                    if bitmap & 1 != 0 {
+                        let value = *compressed_data
+                            .get(current_offset as usize)
+                            .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                        decom_buf.push(value);
+                        current_offset += 1;
+                    } else {
+                        if distance == 0 {
+                            error!(
+                                "[macos-unifiedlogs] Got distance 0 for checked_sub on decompressed data"
+                            );
+                            return Err(nom::Err::Incomplete(Needed::Unknown));
+                        }
+                        let source_offset = decom_buf
+                            .len()
+                            .checked_sub(distance)
+                            .ok_or(nom::Err::Incomplete(Needed::Unknown))?;
+                        let value = decom_buf[source_offset];
+                        decom_buf.push(value);
+                    }
+
+                    bitmap >>= 1;
+                    decom_size -= 1;
+
+                    if decom_size == 0 {
+                        break;
+                    }
+                }
+
+                if decom_size == 0 {
+                    break;
+                }
+            }
+        }
+
+        input = remaining;
+    }
+
+    Ok((input, decom_buf))
+}
+
+/// Get token region associated with lzbitmap
+fn get_tokens(data: &[u8]) -> impl Iterator<Item = u8> + '_ {
+    data.iter().flat_map(|b| [b & 0xf, b >> 4])
+}
+
+/// Determine if the bitmap token should be used again
+fn get_repeat_token<I>(tokens: &mut Peekable<I>, remaining: usize) -> Option<u32>
+where
+    I: Iterator<Item = u8>,
+{
+    if remaining <= 8 {
+        return Some(1);
+    }
+    match tokens.peek() {
+        None => None,
+        Some(&value) if value != 0xf => Some(1),
+        Some(_) => {
+            tokens.next()?;
+            let mut total = 4;
+            let mut value = 0xf;
+            while value == 0xf {
+                value = tokens.next()?;
+
+                total += u32::from(value);
+            }
+
+            Some(total)
+        }
+    }
+}
+
+/// Check if we get unknown flags
+fn check_flags(flag: u8) -> bool {
+    match flag {
+        0x9 | 0xc => true,
+        // These flags could exist but so far have not been seen in wild
+        0x8 | 0xd => {
+            warn!("[macos-unifiedlogs] Got possible flag {flag}");
+            true
+        }
+        _ => {
+            error!("[macos-unifiedlogs] Got unsupported flag {flag}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lzbitmap::lzbitmap_decompress;
+    use std::{fs, path::PathBuf};
+
+    #[test]
+    fn test_decompress_lzbitmap() {
+        let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        test_path.push("tests/test_data/lzbitmap/lzbitmap_zbm.raw");
+
+        let buffer = fs::read(test_path).unwrap();
+
+        let (_, results) = lzbitmap_decompress(&buffer).unwrap();
+        assert!(results.starts_with(&[2, 96, 0, 0, 0, 0, 0, 0, 25,]));
+
+        assert_eq!(results.len(), 62768);
+    }
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -253,7 +253,7 @@ pub fn format_firehose_log_message(
             }
             None => error!(
                 "Failed to split log message ({log_message}) by printf formatter: {}",
-                &values.formatter
+                values.formatter
             ),
         }
     }


### PR DESCRIPTION
This PR adds support for decompressing lzbitmap data using pure Rust.

Starting in Golden Gate the Unified Log data has been observed to be compressed with:
- lz4
- lzbitmap

(lzfse may also be used based on [screenshot in #145](https://github.com/mandiant/macos-UnifiedLogs/issues/145#issuecomment-5189677041). But this has not been seen in wild yet.)

This PR is similar to #146 except it does not use `compression-rs` which leverages Apple APIs.

Based on the logarchive provided in #145. The decompression works correctly.

However, additional work will need to be done to support parsing additional changes introduced in Golden Gate such as Persona info and catalog updates that is mentioned in #146.

In addition, waiting on [approval](https://github.com/mandiant/macos-UnifiedLogs/issues/145#issuecomment-5208437370) from @lukbukkit to see if we can include parts of the provided logarchive as test data. (Test data is not committed) 