### PR TITLE
Firehose updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,23 @@ keywords = ["forensics", "macOS", "unifiedlog"]
 
 [dependencies]
 nom = "8.0.0"
-serde_json = "1.0.149"
-serde = { version = "1.0.228", features = ["derive"] }
-log = "0.4.29"
-lz4_flex = "0.13.0"
+serde_json = "1.0.151"
+serde = { version = "1.0.229", features = ["derive"] }
+log = "0.4.33"
+lz4_flex = "0.14.0"
 byteorder = "1.5.0"
-plist = "1.9.0"
-regex = "1.12.3"
-base64 = "0.22.1"
-chrono = "0.4.44"
+plist = "1.10.0"
+regex = "1.13.1"
+base64 = "0.23.1"
+chrono = "0.4.45"
 walkdir = "2.5.0"
 sunlight = "0.1.5"
 
 [dev-dependencies]
-chrono = "0.4.44"
+chrono = "0.4.45"
 criterion = "0.8.2"
-anyhow = "1.0.102"
-test-case = "3.3"
+anyhow = "1.0.104"
+test-case = "3.3.1"
 
 [[bench]]
 name = "high_sierra_benchmark"

--- a/examples/unifiedlog_iterator/Cargo.toml
+++ b/examples/unifiedlog_iterator/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2024"
 [dependencies]
 simplelog = "0.12.2"
 csv = "1.4.0"
-chrono = "0.4.44"
-log = "0.4.29"
-serde_json = "1.0.149"
+chrono = "0.4.45"
+log = "0.4.33"
+serde_json = "1.0.151"
 macos-unifiedlogs = { path = "../../" }
-clap = { version = "4.6.1", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-libc = "0.2.186"
+clap = { version = "4.6.6", features = ["derive"] }
+serde = { version = "1.0.229", features = ["derive"] }
+libc = "0.2.189"

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -660,7 +660,7 @@ impl FirehosePreamble {
             item.item = FirehoseItem::Precision;
         }
 
-        const SENSITIVE_ITEMS: [u8; 3] = [05, 0x45, 0x85];
+        const SENSITIVE_ITEMS: [u8; 3] = [0x5, 0x45, 0x85];
         if SENSITIVE_ITEMS.contains(&item.item_type) {
             let (input, message_offset) = le_u16(firehose_input)?;
             let (input, message_size) = le_u16(input)?;

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -149,14 +149,16 @@ impl FirehosePreamble {
         let (input, chunk_tag) = le_u32(firehose_input_data)?;
         let (input, chunk_sub_tag) = le_u32(input)?;
         let (input, chunk_data_size) = le_u64(input)?;
-        let (input, first_proc_id) = le_u64(input)?;
+        let (remaining, chunk_data) = take(chunk_data_size)(input)?;
+        let (input, first_proc_id) = le_u64(chunk_data)?;
         let (input, second_proc_id) = le_u32(input)?;
         let (input, ttl) = le_u8(input)?;
         let (input, collapsed) = le_u8(input)?;
+        let (data_start, unknown) = take(size_of::<u16>())(input)?;
 
-        let (input, unknown) = take(size_of::<u16>())(input)?;
-
-        let (input, public_data_size) = le_u16(input)?;
+        // Private data offset starts here
+        // Public data size includes itself
+        let (input, public_data_size) = le_u16(data_start)?;
         let (input, private_data_virtual_offset) = le_u16(input)?;
         let (input, unknown2) = le_u16(input)?;
         let (input, unknown3) = le_u16(input)?;
@@ -178,80 +180,53 @@ impl FirehosePreamble {
         firehose_data.unknown3 = unknown3;
         firehose_data.base_continous_time = base_continous_time;
 
-        // firehose_public_data_size includes the 16 bytes before the public data offset
-        let public_data_size_offset = 16;
-        let (mut input, mut public_data) =
-            take(public_data_size - public_data_size_offset)(log_data)?;
+        // firehose_public_data_size includes itself and the metadata we nommed above (16 bytes)
+        let public_data_nommed_size = 16;
+        let (public_remaining, mut public_data) =
+            take(public_data_size - public_data_nommed_size)(log_data)?;
 
         // Go through all the public data associated with log Firehose entry
         while !public_data.is_empty() {
+            // Start parsing all of them public data
             let (firehose_input, firehose_public_data) =
                 FirehosePreamble::parse_firehose(public_data)?;
             public_data = firehose_input;
+
+            // If not enough data remaining. End early
             if !Self::LOG_TYPES.contains(&firehose_public_data.log_activity_type)
                 || public_data.len() < 24
             {
                 if Self::REMNANT_DATA == firehose_public_data.log_activity_type {
                     break;
                 }
-                if private_data_virtual_offset != 0x1000 {
-                    let private_offst = 0x1000;
-                    let private_data_offset = private_offst - private_data_virtual_offset;
-                    // Calculate start of private data. If the remaining input is greater than private data offset.
-                    // Remove any padding/junk data in front of the private data
-                    if input.len() > private_data_offset as usize && public_data.is_empty() {
-                        let leftover_data = input.len() - private_data_offset as usize;
-                        let (private_data, _) = take(leftover_data)(input)?;
-                        input = private_data;
-                    } else {
-                        // If log data and public data are the same size. Use private data offset to calculate the private data
-                        if log_data.len() == (public_data_size - public_data_size_offset) as usize {
-                            let (private_input_data, _) = take(
-                                (private_data_virtual_offset - public_data_size_offset) as usize
-                                    - public_data.len(),
-                            )(log_data)?;
-                            input = private_input_data;
-                        } else {
-                            // If we have private data, then any leftover public data is actually prepended to the private data
-                            /*
-                            buffer:             2736 bytes
-                                00000000: b0 0a aa 0a 00 00 00 03 19 6d c9 a4 1d 08 00 00 .........m......
-                                ...
-                                00000a90: ce fa d2 b0 10 00 12 00 aa 0a 4b 00 35 60 00 00 ..........K.5`..
-                                00000aa0: 01 00 43 01 21 04 00 00 4b 00 43 6f 6e 66 69 67 ..C.!...K.Config <- Config is actually in private data
-                            privdata:           1366 bytes
-                                00000000: 43 6f 6e 66 69 67 52 65 73 6f 6c 76 65 72 73 3a ConfigResolvers:
-                                00000010: 20 55 6e 73 63 6f 70 65 64 20 72 65 73 6f 6c 76  Unscoped resolv
-                                00000020: 65 72 5b 35 5d 20 64 6f 6d 61 69 6e 20 61 2e 65 er[5] domain a.e
-                                00000030: 2e 66 2e 69 70 36 2e 61 72 70 61 20 6e 5f 6e 61 .f.ip6.arpa n_na
-                                00000040: 6d 65 73 65 72 76 65 72 20 30 00 43 6f 6e 66 69 meserver 0.Confi
-                            */
-                            let (private_input_data, _) = take(
-                                (public_data_size - public_data_size_offset) as usize
-                                    - public_data.len(),
-                            )(log_data)?;
-                            input = private_input_data;
-                        }
-                    }
-                }
                 firehose_data.public_data.push(firehose_public_data);
                 break;
             }
+
             firehose_data.public_data.push(firehose_public_data);
         }
 
+        let private_data_offset_default = 0x1000;
         // If there is private data, go through and update any logs that have private data items
-        if private_data_virtual_offset != 0x1000 {
+        if private_data_virtual_offset != private_data_offset_default {
+            // If Firehose data has been collapsed. Then private data needs to be calculated slightly differently
+            // We need to subtract the private data offset for this chunk from the default private data offset (4096)
+            // And then take whatever is remaining from the public data
+            //
+            // See: https://github.com/libyal/dtformats/blob/main/documentation/Apple%20Unified%20Logging%20and%20Activity%20Tracing%20formats.asciidoc#27-firehose-chunk
+            let private_data = if firehose_data.collapsed == 1
+                || private_data_virtual_offset as usize > data_start.len()
+            {
+                let private_data_size = private_data_offset_default - private_data_virtual_offset;
+                let (_, data) = take(private_data_size)(public_remaining)?;
+                data
+            } else {
+                // Jump to start of private data
+                let (private_data, _) = take(private_data_virtual_offset)(data_start)?;
+                private_data
+            };
+
             debug!("[macos-unifiedlogs] Parsing Private Firehose Data");
-            // Nom any padding
-            let (mut private_input, _) = take_while(|b: u8| b == 0)(input)?;
-
-            // if we nom the rest of the data (all zeros) then the private data is actually zeros
-            // Or if the firehose data is collapsed, then there was no padding
-            if private_input.is_empty() || firehose_data.collapsed == 1 {
-                private_input = input;
-            }
-
             for data in &mut firehose_data.public_data {
                 // Only non-activity firehose entries appears to have private strings
                 if data.firehose_non_activity.private_strings_size == 0 {
@@ -260,13 +235,13 @@ impl FirehosePreamble {
                 // Get the start of private string data
                 let string_offset =
                     data.firehose_non_activity.private_strings_offset - private_data_virtual_offset;
-                let (private_string_start, _) = take(string_offset)(private_input)?;
+                let (private_string_start, _) = take(string_offset)(private_data)?;
                 let _ =
                     FirehosePreamble::parse_private_data(private_string_start, &mut data.message);
             }
-            input = private_input;
         }
-        Ok((input, firehose_data))
+
+        Ok((remaining, firehose_data))
     }
 
     /// Collect all the Firehose items (log message entries) in the log entry (chunk)
@@ -289,7 +264,7 @@ impl FirehosePreamble {
         let number_item_type = [0x0, 0x2];
         // Dynamic precision item types?
         let precision_items = [0x10, 0x12];
-        //  Likely related to private string. Seen only "<private>" values
+        // Likely related to private string. Seen only "<private>" values
         let sensitive_items = [0x45, 0x85];
         let object_items = [0x40, 0x42];
 
@@ -418,6 +393,8 @@ impl FirehosePreamble {
         let mut private_string_start = data;
         // Go through all firehose items, for each private item entry get the private value
         for firehose_info in &mut firehose_item_data.item_info {
+            let private_bitwise_set = 0x8000;
+
             if private_strings.contains(&firehose_info.item_type) {
                 // Base64 encode arbitrary data. Need to further parse them based on base string formatters
                 if firehose_info.item_type == private_strings[3]
@@ -438,11 +415,24 @@ impl FirehosePreamble {
                     firehose_info.message_strings = encode_standard(pointer_object);
                     continue;
                 }
+
                 let null_private = 0;
+
                 // Even null values are marked private
                 if firehose_info.item_size == null_private {
                     firehose_info.message_strings = String::from("<private>");
                 } else {
+                    if (private_bitwise_set & firehose_info.item_size) != 0 {
+                        // If most significate bit is set (0x8000)
+                        // We need to clear it to get the real size
+                        // Ex: 0x83f8 is really 0x3f8
+                        let real_size = firehose_info.item_size & 0x7fff;
+                        let (private_data, private_string) =
+                            extract_string_size(private_string_start, u64::from(real_size))?;
+                        private_string_start = private_data;
+                        firehose_info.message_strings = format!("{private_string}");
+                        continue;
+                    }
                     let (private_data, private_string) = extract_string_size(
                         private_string_start,
                         u64::from(firehose_info.item_size),
@@ -454,9 +444,8 @@ impl FirehosePreamble {
             } else if firehose_info.item_type == Self::PRIVATE_NUMBER
                 || firehose_info.item_type == Self::SENSITIVE_NUMBER
             {
-                let private_number = 0x8000;
                 // Numbers can also be private
-                if firehose_info.item_size == private_number || firehose_info.item_size == 0 {
+                if firehose_info.item_size == private_bitwise_set || firehose_info.item_size == 0 {
                     firehose_info.message_strings = String::from("<private>")
                 } else {
                     let (private_data, private_string) = FirehosePreamble::parse_item_number(
@@ -671,7 +660,7 @@ impl FirehosePreamble {
             item.item = FirehoseItem::Precision;
         }
 
-        const SENSITIVE_ITEMS: [u8; 3] = [0x5, 0x45, 0x85];
+        const SENSITIVE_ITEMS: [u8; 3] = [05, 0x45, 0x85];
         if SENSITIVE_ITEMS.contains(&item.item_type) {
             let (input, message_offset) = le_u16(firehose_input)?;
             let (input, message_size) = le_u16(input)?;
@@ -681,6 +670,7 @@ impl FirehosePreamble {
             item.item = FirehoseItem::Sensitive;
             firehose_input = input;
         }
+
         Ok((firehose_input, item))
     }
 

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -71,7 +71,7 @@ pub struct Firehose {
     pub message: FirehoseItemData,
 }
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, PartialEq)]
 pub struct FirehoseItemType {
     /// Type of item: strings, numbers, objects, precision
     pub item_type: u8,
@@ -94,6 +94,7 @@ pub enum FirehoseItem {
     Precision,
     Sensitive,
     Object,
+    SensitiveNumber,
     #[default]
     Unknown,
 }
@@ -122,7 +123,7 @@ pub enum MessageFlags {
     HasPersona,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct FirehoseItemData {
     pub item_info: Vec<FirehoseItemType>,
     pub backtrace_strings: Vec<String>,
@@ -133,6 +134,7 @@ impl FirehosePreamble {
     /// Remaining data (if any) contains strings for the string item types
     const STRING_ITEM: [u8; 8] = [0x20, 0x22, 0x40, 0x42, 0x30, 0x31, 0x32, 0xf2];
     const PRIVATE_NUMBER: u8 = 0x1;
+    const SENSITIVE_NUMBER: u8 = 0x5;
     /// 0x81 and 0xf1 Added in macOS Sequioa
     const PRIVATE_STRINGS: [u8; 7] = [0x21, 0x25, 0x35, 0x31, 0x41, 0x81, 0xf1];
     const LOG_TYPES: [u8; 5] = [0x2, 0x6, 0x4, 0x7, 0x3];
@@ -287,13 +289,12 @@ impl FirehosePreamble {
         let number_item_type = [0x0, 0x2];
         // Dynamic precision item types?
         let precision_items = [0x10, 0x12];
-        //  Likely realted to private string. Seen only "<private>" values
-        // 0x85 and 0x5 added in macOS Sequioa
-        let sensitive_items = [0x5, 0x45, 0x85];
+        //  Likely related to private string. Seen only "<private>" values
+        let sensitive_items = [0x45, 0x85];
         let object_items = [0x40, 0x42];
 
         while item_count < firehose_number_items {
-            // Get non-number values first since the values are at the end of the of the log (chunk) entry data
+            // Get non-number values first since the values are at the end of the (chunk) entry data
             let (item_value_input, mut item) =
                 FirehosePreamble::get_firehose_items(firehose_input)?;
             firehose_input = item_value_input;
@@ -367,6 +368,12 @@ impl FirehosePreamble {
                 continue;
             }
 
+            if item.item_type == Self::SENSITIVE_NUMBER {
+                item.item = FirehoseItem::SensitiveNumber;
+                item.message_strings = String::from("<private>");
+                continue;
+            }
+
             if item.item_type == Self::PRIVATE_NUMBER {
                 continue;
             }
@@ -407,7 +414,6 @@ impl FirehosePreamble {
         firehose_item_data: &mut FirehoseItemData,
     ) -> nom::IResult<&'a [u8], ()> {
         let private_strings: Vec<u8> = vec![0x21, 0x25, 0x41, 0x35, 0x31, 0x81, 0xf1];
-        let private_number = 0x1;
 
         let mut private_string_start = data;
         // Go through all firehose items, for each private item entry get the private value
@@ -445,10 +451,12 @@ impl FirehosePreamble {
                     private_string_start = private_data;
                     firehose_info.message_strings = private_string;
                 }
-            } else if firehose_info.item_type == private_number {
+            } else if firehose_info.item_type == Self::PRIVATE_NUMBER
+                || firehose_info.item_type == Self::SENSITIVE_NUMBER
+            {
                 let private_number = 0x8000;
                 // Numbers can also be private
-                if firehose_info.item_size == private_number {
+                if firehose_info.item_size == private_number || firehose_info.item_size == 0 {
                     firehose_info.message_strings = String::from("<private>")
                 } else {
                     let (private_data, private_string) = FirehosePreamble::parse_item_number(
@@ -572,7 +580,7 @@ impl FirehosePreamble {
             }
         };
         let (mut input, _) = take(padding_data)(input)?;
-        if (padding_data as usize) > taken_data.len() {
+        if padding_data > taken_data.len() {
             input = remaining_data;
         }
 
@@ -636,12 +644,11 @@ impl FirehosePreamble {
         const STRING_ITEM: [u8; 14] = [
             0x20, 0x21, 0x22, 0x25, 0x40, 0x41, 0x42, 0x30, 0x31, 0x32, 0xf2, 0x35, 0x81, 0xf1,
         ];
-        const PRIVATE_NUMBER: u8 = 0x1;
 
         // String and private number items metadata is 4 bytes
         // first two (2) bytes point to the offset of the string data
         // last two (2) bytes is the size of of string
-        if STRING_ITEM.contains(&item.item_type) || item.item_type == PRIVATE_NUMBER {
+        if STRING_ITEM.contains(&item.item_type) || item.item_type == Self::PRIVATE_NUMBER {
             // The offset is relative to start of string data (after all other firehose items)
             let (input, message_offset) = le_u16(firehose_input)?;
             let (input, message_size) = le_u16(input)?;
@@ -652,7 +659,7 @@ impl FirehosePreamble {
             firehose_input = input;
         }
 
-        if item.item_type == PRIVATE_NUMBER {
+        if item.item_type == Self::PRIVATE_NUMBER {
             item.item = FirehoseItem::PrivateNumber;
         }
 
@@ -725,11 +732,9 @@ impl FirehosePreamble {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, io::Read, path::PathBuf};
-
-    use crate::chunks::firehose::firehose_log::{FirehoseItem, FirehoseItemType};
-
     use super::{FirehoseItemData, FirehosePreamble};
+    use crate::chunks::firehose::firehose_log::{FirehoseItem, FirehoseItemType};
+    use std::{fs::File, io::Read, path::PathBuf};
 
     #[test]
     fn test_parse_firehose_preamble() {
@@ -3163,6 +3168,44 @@ mod tests {
     }
 
     #[test]
+    fn test_collect_items_sensitive_number() {
+        let test = [37, 4, 0, 0, 0, 0, 5, 4, 0, 0, 0, 128, 37, 4, 0, 0, 0, 0];
+        let (_, results) = FirehosePreamble::collect_items(&test, 3, 548).unwrap();
+        assert_eq!(
+            results,
+            FirehoseItemData {
+                item_info: vec![
+                    FirehoseItemType {
+                        item_type: 37,
+                        item_type_size: 4,
+                        offset: 0,
+                        item_size: 0,
+                        message_strings: String::from("<private>"),
+                        item: FirehoseItem::PrivateString
+                    },
+                    FirehoseItemType {
+                        item_type: 5,
+                        item_type_size: 4,
+                        offset: 0,
+                        item_size: 32768,
+                        message_strings: String::from("<private>"),
+                        item: FirehoseItem::SensitiveNumber
+                    },
+                    FirehoseItemType {
+                        item_type: 37,
+                        item_type_size: 4,
+                        offset: 0,
+                        item_size: 0,
+                        message_strings: String::from("<private>"),
+                        item: FirehoseItem::PrivateString
+                    }
+                ],
+                backtrace_strings: Vec::new()
+            }
+        );
+    }
+
+    #[test]
     fn test_parse_firehose_preamble_private_public_values() {
         let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_path.push("tests/test_data/Chunkset Tests/private_public_data.raw");
@@ -3529,5 +3572,40 @@ mod tests {
             }
             panic!("Got wrong message strings: {entry:?}");
         }
+    }
+
+    #[test]
+    fn test_parse_private_data_sensitive_number() {
+        let mut items = FirehoseItemData {
+            item_info: vec![
+                FirehoseItemType {
+                    item_type: 37,
+                    item_type_size: 4,
+                    offset: 0,
+                    item_size: 0,
+                    message_strings: String::from("<private>"),
+                    item: FirehoseItem::PrivateString,
+                },
+                FirehoseItemType {
+                    item_type: 5,
+                    item_type_size: 4,
+                    offset: 0,
+                    item_size: 32768,
+                    message_strings: String::from("<private>"),
+                    item: FirehoseItem::SensitiveNumber,
+                },
+                FirehoseItemType {
+                    item_type: 37,
+                    item_type_size: 4,
+                    offset: 0,
+                    item_size: 0,
+                    message_strings: String::from("<private>"),
+                    item: FirehoseItem::PrivateString,
+                },
+            ],
+            backtrace_strings: Vec::new(),
+        };
+
+        FirehosePreamble::parse_private_data(&[], &mut items).unwrap();
     }
 }

--- a/src/decoders/dns.rs
+++ b/src/decoders/dns.rs
@@ -566,9 +566,11 @@ pub(crate) fn dns_acceptable(data: &str) -> String {
 pub(crate) fn dns_getaddrinfo_opts(data: &str) -> Result<&'static str, DecoderError<'_>> {
     let message = match data {
         "0" => "0x0 {}",
+        "4" => "0x4 {in-app-browser}",
         "8" => "0x8 {use-failover}",
         "12" => "0xC {in-app-browser, use-failover}",
         "24" => "0x18 {use-failover, prohibit-encrypted-dns}",
+        "32" => "0x20 {use-cache-only}",
         _ => {
             return Err(DecoderError::Parse {
                 input: data.as_bytes(),

--- a/src/message.rs
+++ b/src/message.rs
@@ -996,7 +996,7 @@ fn parse_int(message: String) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::chunks::firehose::firehose_log::FirehoseItemType;
+    use crate::chunks::firehose::firehose_log::{FirehoseItem, FirehoseItemType};
     use crate::message::{
         Alignment, MessageFormatters, NumberFormat, Padding, format_firehose_log_message,
         format_message, format_message_padding, parse_float, parse_formatter, parse_int,
@@ -1017,6 +1017,69 @@ mod tests {
 
         let log_string = format_firehose_log_message(test_data, &item_message, &message_re);
         assert_eq!(log_string, "opendirectoryd (build 796.100) launched...")
+    }
+
+    #[test]
+    fn test_format_firehose_log_message_tricky() {
+        let test = String::from(
+            "<%{public}@:%p> creating new multiplexing view controller controller <%{public}@:%p> for %{public}@ at level: %.f",
+        );
+        let items = vec![
+            FirehoseItemType {
+                item_type: 66,
+                item_type_size: 4,
+                offset: 0,
+                item_size: 23,
+                message_strings: String::from("SBHMultiplexingManager"),
+                item: FirehoseItem::String,
+            },
+            FirehoseItemType {
+                item_type: 0,
+                item_type_size: 8,
+                offset: 0,
+                item_size: 0,
+                message_strings: String::from("936749223363120960"),
+                item: FirehoseItem::Number,
+            },
+            FirehoseItemType {
+                item_type: 66,
+                item_type_size: 4,
+                offset: 23,
+                item_size: 30,
+                message_strings: String::from("SBHMultiplexingViewController"),
+                item: FirehoseItem::String,
+            },
+            FirehoseItemType {
+                item_type: 0,
+                item_type_size: 8,
+                offset: 0,
+                item_size: 0,
+                message_strings: String::from("1008806817370365440"),
+                item: FirehoseItem::Number,
+            },
+            FirehoseItemType {
+                item_type: 66,
+                item_type_size: 4,
+                offset: 53,
+                item_size: 37,
+                message_strings: String::from("D8F2438E-AACF-4ED9-AD47-F5A1598215C7"),
+                item: FirehoseItem::String,
+            },
+            FirehoseItemType {
+                item_type: 0,
+                item_type_size: 8,
+                offset: 0,
+                item_size: 0,
+                message_strings: String::from("0"),
+                item: FirehoseItem::Number,
+            },
+        ];
+        let message_re = Regex::new(r"(%(?:(?:\{[^}]+}?)(?:[-+0#]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*)?)?(?:h|hh|l|ll|w|I|z|t|q|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%}]|(?:[-+0 #]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*)?)?(?:h|hh|l||q|t|ll|w|I|z|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%]))").unwrap();
+        let log_string = format_firehose_log_message(test, &items, &message_re);
+        assert_eq!(
+            log_string,
+            "<SBHMultiplexingManager:D0000749E2E8F40> creating new multiplexing view controller controller <SBHMultiplexingViewController:E0000749C5A5E00> for D8F2438E-AACF-4ED9-AD47-F5A1598215C7 at level: 0"
+        )
     }
 
     #[test]

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -126,7 +126,7 @@ where
         (?:{[^}]+}?)                      # Get String formatters with %{<variable>}<variable> values. Ex: %{public}#llx with team ID %{public}@
         (?:[-+0#]{0,5})                   # optional flags
         (?:\d+|\*)?                       # width
-        (?:\.(?:\d+|\*))?                 # precision
+        (?:\.(?:\d+|\*)?)?                 # precision
         (?:h|hh|l|ll|t|q|w|I|z|I32|I64)?  # size
         [cCdiouxXeEfgGaAnpsSZPm@}]       # type
 
@@ -134,13 +134,13 @@ where
 
         (?:[-+0 #]{0,5})                  # optional flags
         (?:\d+|\*)?                       # width
-        (?:\.(?:\d+|\*))?                 # precision
+        (?:\.(?:\d+|\*)?)?                 # precision
         (?:h|hh|l|ll|w|I|t|q|z|I32|I64)?  # size
         [cCdiouxXeEfgGaAnpsSZPm@%]        # type
         ))
         */
         let message_re_result = Regex::new(
-            r"(%(?:(?:\{[^}]+}?)(?:[-+0#]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*))?(?:h|hh|l|ll|w|I|z|t|q|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@}]|(?:[-+0 #]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*))?(?:h|hh|l||q|t|ll|w|I|z|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%]))",
+            r"(%(?:(?:\{[^}]+}?)(?:[-+0#]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*)?)?(?:h|hh|l|ll|w|I|z|t|q|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@}]|(?:[-+0 #]{0,5})(?:\d+|\*)?(?:\.(?:\d+|\*)?)?(?:h|hh|l||q|t|ll|w|I|z|I32|I64)?[cmCdiouxXeEfgGaAnpsSZP@%]))",
         );
         let message_re = match message_re_result {
             Ok(message_re) => message_re,

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,7 +59,7 @@ pub(crate) fn extract_string_size(data: &[u8], message_size: u64) -> nom::IResul
         match path_string {
             Ok(results) => return Ok((input, results.trim_end_matches(char::from(0)).to_string())),
             Err(err) => {
-                panic!("[macos-unifiedlogs] Failed to get extract specific string size: {err:?}")
+                error!("[macos-unifiedlogs] Failed to get extract specific string size: {err:?}")
             }
         }
     }
@@ -82,10 +82,11 @@ pub(crate) fn extract_string_size(data: &[u8], message_size: u64) -> nom::IResul
         Ok(results) => return Ok((input, results.trim_end_matches(char::from(0)).to_string())),
         Err(err) => error!("[macos-unifiedlogs] Failed to get specific string: {err:?}"),
     }
-    println!("size: {message_size}");
-    println!("{data:?}");
-    panic!("what???");
-    Ok((input, String::from("Could not find path string")))
+
+    Ok((
+        input,
+        String::from("[macos-unifiedlogs Could not extract string"),
+    ))
 }
 
 const NULL_BYTE: u8 = 0;

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,7 +59,7 @@ pub(crate) fn extract_string_size(data: &[u8], message_size: u64) -> nom::IResul
         match path_string {
             Ok(results) => return Ok((input, results.trim_end_matches(char::from(0)).to_string())),
             Err(err) => {
-                error!("[macos-unifiedlogs] Failed to get extract specific string size: {err:?}")
+                panic!("[macos-unifiedlogs] Failed to get extract specific string size: {err:?}")
             }
         }
     }
@@ -82,6 +82,9 @@ pub(crate) fn extract_string_size(data: &[u8], message_size: u64) -> nom::IResul
         Ok(results) => return Ok((input, results.trim_end_matches(char::from(0)).to_string())),
         Err(err) => error!("[macos-unifiedlogs] Failed to get specific string: {err:?}"),
     }
+    println!("size: {message_size}");
+    println!("{data:?}");
+    panic!("what???");
     Ok((input, String::from("Could not find path string")))
 }
 


### PR DESCRIPTION
Some minor updates when parsing firehose chunks:
1. Support for for sensitive numbers
2. Improved private data parsing
3. Reduced complexity


This PR also adds support for empty precision values. Ex: `%.f`. This defaults to 0 precision.
Minor DNS decoder updates too