### PR TITLE
Read the inline persona only when the catalog records none

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -125,7 +125,31 @@ pub struct CatalogPersona {
     uuid: String,
 }
 
+impl ProcessInfoEntry {
+    /// `persona_id` values that mean the catalog records no persona for the process.
+    ///
+    /// `0xFFFFFFFF` is what `log` itself renders as `NOPERSONA`; `0xAAAAAAAA` is an
+    /// uninitialized-memory pattern seen in the same field.
+    const NO_PERSONA: [u32; 2] = [0xFFFF_FFFF, 0xAAAA_AAAA];
+
+    /// The persona a `persona_id` field names, or `None` when it holds a sentinel.
+    pub(crate) fn persona(persona_id: u32) -> Option<u32> {
+        (!Self::NO_PERSONA.contains(&persona_id)).then_some(persona_id)
+    }
+}
+
 impl CatalogChunk {
+    /// The persona the catalog records for a process, if it records one.
+    ///
+    /// A firehose tracepoint carries its persona id inline only when this is `None`. When the
+    /// catalog already knows the persona, the entry still sets the `has_persona` flag but no
+    /// field follows it -- reading one anyway consumes the start of the item list and shifts
+    /// every field after it. See `FirehosePreamble::parse_firehose`.
+    pub fn persona_for(&self, first_proc_id: u64, second_proc_id: u32) -> Option<u32> {
+        self.catalog_process_info_entries
+            .get(&format!("{first_proc_id}_{second_proc_id}"))
+            .and_then(|entry| ProcessInfoEntry::persona(entry.persona_id))
+    }
     /// Parse log Catalog data. The log Catalog contains metadata related to log entries such as Process info, Subsystem info, and the compressed log entries
     pub fn parse_catalog(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, preamble) = LogPreamble::parse(input)?;
@@ -543,6 +567,7 @@ impl CatalogChunk {
 mod tests {
     use super::CatalogChunk;
     use crate::catalog::CatalogPersona;
+    use crate::catalog::ProcessInfoEntry;
     use std::fs;
     use std::path::PathBuf;
 
@@ -821,5 +846,13 @@ mod tests {
                 }
             ]
         )
+    }
+
+    #[test]
+    fn persona_sentinels_are_not_personas() {
+        assert_eq!(ProcessInfoEntry::persona(99), Some(99));
+        assert_eq!(ProcessInfoEntry::persona(1000), Some(1000));
+        assert_eq!(ProcessInfoEntry::persona(0xFFFF_FFFF), None);
+        assert_eq!(ProcessInfoEntry::persona(0xAAAA_AAAA), None);
     }
 }

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -36,6 +36,7 @@ impl FirehoseActivity {
         data: &[u8],
         firehose_flags: u16,
         firehose_log_type: u8,
+        catalog_persona: Option<u32>,
     ) -> nom::IResult<&[u8], FirehoseActivity> {
         let mut activity = FirehoseActivity::default();
         let mut input = data;
@@ -77,12 +78,18 @@ impl FirehoseActivity {
         let has_persona = 0x40;
         if (firehose_flags & has_persona) != 0 {
             debug!("[macos-unifiedlogs] Activity Firehose log chunk has has_persona flag");
-            let (firehose_input, persona_id) = le_u32(input)?;
-
-            activity.persona_id = persona_id;
             activity.flags.push(MessageFlags::HasPersona);
 
-            input = firehose_input;
+            // The persona is inline only when the catalog does not already record one for this
+            // process. When it does, the flag is still set but no field follows it.
+            match catalog_persona {
+                Some(persona_id) => activity.persona_id = persona_id,
+                None => {
+                    let (firehose_input, persona_id) = le_u32(input)?;
+                    activity.persona_id = persona_id;
+                    input = firehose_input;
+                }
+            }
         }
 
         let activity_id_other = 0x200; // has_other_current_aid flag. In Activity log entries this is another activity id flag
@@ -157,7 +164,7 @@ mod tests {
         let test_flags = 573;
         let log_type: u8 = 0x1;
         let (_, results) =
-            FirehoseActivity::parse_activity(&test_data, test_flags, log_type).unwrap();
+            FirehoseActivity::parse_activity(&test_data, test_flags, log_type, None).unwrap();
         assert_eq!(results.activity_id, 64434);
         assert_eq!(results.sentinal, 2147483648);
         assert_eq!(results.pid, 236);

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -5,6 +5,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
+use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::activity::FirehoseActivity;
 use crate::chunks::firehose::loss::FirehoseLoss;
 use crate::chunks::firehose::nonactivity::FirehoseNonActivity;
@@ -141,9 +142,10 @@ impl FirehosePreamble {
     const REMNANT_DATA: u8 = 0x0;
 
     /// Parse the start of the Firehose data
-    pub fn parse_firehose_preamble(
-        firehose_input_data: &[u8],
-    ) -> nom::IResult<&[u8], FirehosePreamble> {
+    pub fn parse_firehose_preamble<'a>(
+        firehose_input_data: &'a [u8],
+        catalog: &CatalogChunk,
+    ) -> nom::IResult<&'a [u8], FirehosePreamble> {
         let mut firehose_data = FirehosePreamble::default();
 
         let (input, chunk_tag) = le_u32(firehose_input_data)?;
@@ -186,10 +188,14 @@ impl FirehosePreamble {
             take(public_data_size - public_data_nommed_size)(log_data)?;
 
         // Go through all the public data associated with log Firehose entry
+        // Whether the persona is inline in each tracepoint depends on the emitting process, not
+        // on the tracepoint, so it is resolved once per chunk.
+        let catalog_persona = catalog.persona_for(first_proc_id, second_proc_id);
+
         while !public_data.is_empty() {
             // Start parsing all of them public data
             let (firehose_input, firehose_public_data) =
-                FirehosePreamble::parse_firehose(public_data)?;
+                FirehosePreamble::parse_firehose(public_data, catalog_persona)?;
             public_data = firehose_input;
 
             // If not enough data remaining. End early
@@ -461,7 +467,7 @@ impl FirehosePreamble {
     }
 
     /// Parse all the different types of Firehose data (activity, non-activity, loss, trace, signpost)
-    fn parse_firehose(data: &[u8]) -> nom::IResult<&[u8], Firehose> {
+    fn parse_firehose(data: &[u8], catalog_persona: Option<u32>) -> nom::IResult<&[u8], Firehose> {
         let mut firehose_results = Firehose::default();
 
         let (input, log_activity_type) = le_u8(data)?;
@@ -498,17 +504,17 @@ impl FirehosePreamble {
 
         if log_activity_type == activity {
             let (activity_data, activity) =
-                FirehoseActivity::parse_activity(firehose_input, flags, log_type)?;
+                FirehoseActivity::parse_activity(firehose_input, flags, log_type, catalog_persona)?;
             firehose_input = activity_data;
             firehose_results.firehose_activity = activity;
         } else if log_activity_type == nonactivity {
             let (non_activity_data, non_activity) =
-                FirehoseNonActivity::parse_non_activity(firehose_input, flags)?;
+                FirehoseNonActivity::parse_non_activity(firehose_input, flags, catalog_persona)?;
             firehose_input = non_activity_data;
             firehose_results.firehose_non_activity = non_activity;
         } else if log_activity_type == signpost {
             let (process_data, firehose_signpost) =
-                FirehoseSignpost::parse_signpost(firehose_input, flags)?;
+                FirehoseSignpost::parse_signpost(firehose_input, flags, catalog_persona)?;
             firehose_input = process_data;
             firehose_results.firehose_signpost = firehose_signpost;
         } else if log_activity_type == loss {
@@ -723,6 +729,7 @@ impl FirehosePreamble {
 #[cfg(test)]
 mod tests {
     use super::{FirehoseItemData, FirehosePreamble};
+    use crate::catalog::CatalogChunk;
     use crate::chunks::firehose::firehose_log::{FirehoseItem, FirehoseItemType};
     use std::{fs::File, io::Read, path::PathBuf};
 
@@ -2801,8 +2808,11 @@ mod tests {
             0, 0, 0, 0, 0, 2, 1, 4, 0, 48, 57, 126, 0, 179, 232, 0, 0, 0, 0, 0, 0, 40, 101, 197, 1,
             16, 0, 12, 0, 178, 249, 0, 0, 0, 0, 0, 128, 105, 67, 61, 0, 0, 0, 0, 0,
         ];
-        let (mut data, firehose) =
-            FirehosePreamble::parse_firehose_preamble(&test_firehose_data).unwrap();
+        let (mut data, firehose) = FirehosePreamble::parse_firehose_preamble(
+            &test_firehose_data,
+            &CatalogChunk::default(),
+        )
+        .unwrap();
         assert_eq!(firehose.chunk_tag, 0x6001);
         assert_eq!(firehose.chunk_sub_tag, 0);
         assert_eq!(firehose.chunk_data_size, 4032);
@@ -2819,7 +2829,8 @@ mod tests {
 
         let mut firehouse_result_count = firehose.public_data.len();
         while !data.is_empty() {
-            let (test_data, firehose) = FirehosePreamble::parse_firehose_preamble(data).unwrap();
+            let (test_data, firehose) =
+                FirehosePreamble::parse_firehose_preamble(data, &CatalogChunk::default()).unwrap();
             data = test_data;
             firehouse_result_count += firehose.public_data.len();
         }
@@ -2843,7 +2854,7 @@ mod tests {
             51, 53, 48, 52, 53, 48, 40, 53, 48, 49, 41, 62, 58, 54, 52, 49, 93, 0, 0, 0, 0, 0, 0,
         ];
 
-        let (_, firehose) = FirehosePreamble::parse_firehose(&test_firehose_data).unwrap();
+        let (_, firehose) = FirehosePreamble::parse_firehose(&test_firehose_data, None).unwrap();
         assert_eq!(firehose.log_activity_type, 4);
         assert_eq!(firehose.log_type, 0);
         assert_eq!(firehose.flags, 557);
@@ -2920,7 +2931,8 @@ mod tests {
             22, 0, 8, 0, 140, 94, 64, 6, 1, 0, 0, 0, 4, 0, 4, 2, 96, 153, 65, 6, 175, 149, 170, 0,
             0, 0, 0, 0, 167, 26, 131, 253, 22, 0, 8, 0, 216, 115, 64, 6, 1, 0, 0, 0, 0, 0,
         ];
-        let (_, results) = FirehosePreamble::parse_firehose_preamble(&data).unwrap();
+        let (_, results) =
+            FirehosePreamble::parse_firehose_preamble(&data, &CatalogChunk::default()).unwrap();
         assert_eq!(results.private_data_virtual_offset, 4094);
         assert_eq!(results.first_number_proc_id, 1189179);
         assert_eq!(results.second_number_proc_id, 2685254);
@@ -2981,7 +2993,9 @@ mod tests {
             99, 47, 115, 101, 99, 117, 114, 105, 116, 121, 45, 99, 104, 101, 99, 107, 115, 121,
             115, 116, 101, 109, 0,
         ];
-        let (_, firehose) = FirehosePreamble::parse_firehose_preamble(&test_data).unwrap();
+        let (_, firehose) =
+            FirehosePreamble::parse_firehose_preamble(&test_data, &CatalogChunk::default())
+                .unwrap();
         assert_eq!(firehose.chunk_tag, 0x6001);
         assert_eq!(firehose.chunk_sub_tag, 0);
         assert_eq!(firehose.chunk_data_size, 163);
@@ -3205,7 +3219,8 @@ mod tests {
         let mut buffer = Vec::new();
         open.read_to_end(&mut buffer).unwrap();
 
-        let (_, results) = FirehosePreamble::parse_firehose_preamble(&buffer).unwrap();
+        let (_, results) =
+            FirehosePreamble::parse_firehose_preamble(&buffer, &CatalogChunk::default()).unwrap();
 
         assert_eq!(results.public_data.len(), 51);
 
@@ -3478,7 +3493,9 @@ mod tests {
             0, 0, 0, 0,
         ];
 
-        let (mut data, firehose) = FirehosePreamble::parse_firehose_preamble(&test_data).unwrap();
+        let (mut data, firehose) =
+            FirehosePreamble::parse_firehose_preamble(&test_data, &CatalogChunk::default())
+                .unwrap();
         assert_eq!(firehose.chunk_tag, 0x6001);
         assert_eq!(firehose.chunk_sub_tag, 0);
         assert_eq!(firehose.chunk_data_size, 4104);
@@ -3495,7 +3512,8 @@ mod tests {
 
         let mut firehouse_result_count = firehose.public_data.len();
         while !data.is_empty() {
-            let (test_data, firehose) = FirehosePreamble::parse_firehose_preamble(data).unwrap();
+            let (test_data, firehose) =
+                FirehosePreamble::parse_firehose_preamble(data, &CatalogChunk::default()).unwrap();
             data = test_data;
             firehouse_result_count += firehose.public_data.len();
         }
@@ -3597,5 +3615,49 @@ mod tests {
         };
 
         FirehosePreamble::parse_private_data(&[], &mut items).unwrap();
+    }
+
+    /// A non-activity tracepoint from a process whose catalog `ProcessInfoEntry` records a real
+    /// persona (`persona_id = 99`). `flags` has `0x40` set, but because the catalog already
+    /// knows the persona the tracepoint carries **no** inline persona field.
+    ///
+    /// 24-byte header, the 129-byte body its `data_size` states, then 7 bytes of padding.
+    /// Apple's `log show` renders it as:
+    ///
+    /// ```text
+    /// Requesting container lookup; personaid = 4294967295, type = NOPERSONA, name = <unknown>,
+    ///   origin [pid = 519, personaid = 4294967295], proximate [pid = 519, personaid = 4294967295],
+    ///   class = 4, identifier = <private>, group_identifier = <private>,
+    ///   create = 0, temp = 0, euid = 501, uid = 501
+    /// ```
+    const PERSONA_ABSENT_ENTRY: [u8; 160] = [
+        4, 0, 69, 6, 111, 222, 77, 13, 54, 26, 0, 0, 0, 0, 0, 0, 68, 163, 39, 91, 0, 0, 129, 0,
+        229, 87, 1, 0, 0, 0, 0, 128, 52, 196, 76, 13, 50, 0, 7, 35, 14, 0, 4, 255, 255, 255, 255,
+        34, 4, 0, 0, 10, 0, 34, 4, 10, 0, 10, 0, 0, 4, 7, 2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 4,
+        7, 2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 8, 4, 0, 0, 0, 0, 0, 0, 0, 33, 4, 0, 0, 0, 0, 33,
+        4, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 4, 245, 1, 0, 0, 0, 4, 245, 1, 0, 0,
+        78, 79, 80, 69, 82, 83, 79, 78, 65, 0, 60, 117, 110, 107, 110, 111, 119, 110, 62, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+
+    #[test]
+    fn persona_field_is_absent_when_catalog_records_a_persona() {
+        let (_, firehose) =
+            FirehosePreamble::parse_firehose(&PERSONA_ABSENT_ENTRY, Some(99)).unwrap();
+
+        let items = &firehose.message.item_info;
+        assert_eq!(
+            items.len(),
+            14,
+            "expected the 14 items the format string takes"
+        );
+
+        let values: Vec<&str> = items.iter().map(|i| i.message_strings.as_str()).collect();
+        assert_eq!(values[1], "NOPERSONA");
+        assert_eq!(values[2], "<unknown>");
+        assert_eq!(values[3], "519");
+        assert_eq!(values[8], "<private>");
+        assert_eq!(values[12], "501");
+        assert_eq!(values[13], "501");
     }
 }

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -35,6 +35,7 @@ impl FirehoseNonActivity {
     pub fn parse_non_activity(
         data: &[u8],
         firehose_flags: u16,
+        catalog_persona: Option<u32>,
     ) -> nom::IResult<&[u8], FirehoseNonActivity> {
         let mut non_activity = FirehoseNonActivity::default();
 
@@ -54,12 +55,18 @@ impl FirehoseNonActivity {
         let has_persona = 0x40;
         if (firehose_flags & has_persona) != 0 {
             debug!("[macos-unifiedlogs] Non-Activity Firehose log chunk has has_persona flag");
-            let (firehose_input, persona_id) = le_u32(input)?;
-
-            non_activity.persona_id = persona_id;
             non_activity.flags.push(MessageFlags::HasPersona);
 
-            input = firehose_input;
+            // The persona is inline only when the catalog does not already record one for this
+            // process. When it does, the flag is still set but no field follows it.
+            match catalog_persona {
+                Some(persona_id) => non_activity.persona_id = persona_id,
+                None => {
+                    let (firehose_input, persona_id) = le_u32(input)?;
+                    non_activity.persona_id = persona_id;
+                    input = firehose_input;
+                }
+            }
         }
 
         let private_string_range = 0x100; // has_private_data flag
@@ -166,7 +173,7 @@ mod tests {
         ];
         let test_flags = 556;
         let (_, nonactivity_results) =
-            FirehoseNonActivity::parse_non_activity(&test_data, test_flags).unwrap();
+            FirehoseNonActivity::parse_non_activity(&test_data, test_flags, None).unwrap();
         assert_eq!(nonactivity_results.activity_id, 0);
         assert_eq!(nonactivity_results.sentinel, 0);
         assert_eq!(nonactivity_results.private_strings_offset, 0);
@@ -253,7 +260,7 @@ mod tests {
             49, 52, 48, 57, 52, 49, 48, 0,
         ];
         let flags = 580;
-        let (_, result) = FirehoseNonActivity::parse_non_activity(&test, flags).unwrap();
+        let (_, result) = FirehoseNonActivity::parse_non_activity(&test, flags, None).unwrap();
         assert_eq!(
             result.flags,
             vec![

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -36,6 +36,7 @@ impl FirehoseSignpost {
     pub fn parse_signpost(
         data: &[u8],
         firehose_flags: u16,
+        catalog_persona: Option<u32>,
     ) -> nom::IResult<&[u8], FirehoseSignpost> {
         let mut firehose_signpost = FirehoseSignpost::default();
 
@@ -55,12 +56,18 @@ impl FirehoseSignpost {
         let has_persona = 0x40;
         if (firehose_flags & has_persona) != 0 {
             debug!("[macos-unifiedlogs] Signpost Firehose has has_persona flag");
-            let (firehose_input, persona_id) = le_u32(input)?;
-
-            firehose_signpost.persona_id = persona_id;
             firehose_signpost.flags.push(MessageFlags::HasPersona);
 
-            input = firehose_input;
+            // The persona is inline only when the catalog does not already record one for this
+            // process. When it does, the flag is still set but no field follows it.
+            match catalog_persona {
+                Some(persona_id) => firehose_signpost.persona_id = persona_id,
+                None => {
+                    let (firehose_input, persona_id) = le_u32(input)?;
+                    firehose_signpost.persona_id = persona_id;
+                    input = firehose_input;
+                }
+            }
         }
 
         let private_string_range = 0x100; // has_private_data flag
@@ -181,7 +188,7 @@ mod tests {
             225, 244, 2, 0, 1, 0, 238, 238, 178, 178, 181, 176, 238, 238, 176, 63, 27, 0, 0, 0,
         ];
         let test_flags = 33282;
-        let (_, results) = FirehoseSignpost::parse_signpost(&test_data, test_flags).unwrap();
+        let (_, results) = FirehoseSignpost::parse_signpost(&test_data, test_flags, None).unwrap();
         assert_eq!(results.pc_id, 193761);
         assert_eq!(results.activity_id, 0);
         assert_eq!(results.sentinel, 0);
@@ -259,7 +266,7 @@ mod tests {
             219, 90, 1, 0, 0, 3, 0, 4, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 4, 10, 0, 0, 0,
         ];
         let flags = 33380;
-        let (_, result) = FirehoseSignpost::parse_signpost(&test, flags).unwrap();
+        let (_, result) = FirehoseSignpost::parse_signpost(&test, flags, None).unwrap();
         assert_eq!(
             result.flags,
             vec![

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -162,7 +162,8 @@ impl ChunksetChunk {
         let simpledump_chunk = 0x6004;
 
         if chunk_type == firehose_chunk {
-            let firehose_results = FirehosePreamble::parse_firehose_preamble(data);
+            let firehose_results =
+                FirehosePreamble::parse_firehose_preamble(data, &unified_log_data.catalog);
             match firehose_results {
                 Ok((_, firehose_data)) => unified_log_data.firehose.push(firehose_data),
                 Err(err) => error!(


### PR DESCRIPTION
The has_persona flag (0x40) does not by itself mean a 4-byte persona_id follows the flag-driven fields. A tracepoint carries its persona inline only when the catalog's ProcessInfoEntry does not already record one for the emitting process; when it does, the flag is set but no field follows. Reading one anyway consumed the start of the item list and shifted every field after it.

Measured on a Golden Gate archive over 47,696 classified non-activity entries: 47,223 carry the field (catalog persona_id is the 0xFFFFFFFF NOPERSONA sentinel, or 0xAAAAAAAA) and 473 do not (catalog records a real persona, 99 here). The split is perfectly per-process. 12 processes never carry it, 248 always do, no overlap and no counterexample. As a control, 397,327 sampled entries with 0x40 clear never carry the field, so the flag is a genuine precondition, just not a sufficient one.

Confirmed against Apple's own decoder: `log show` renders one affected entry as "Requesting container lookup; personaid = ..., euid = 501, uid = 501", and the tracepoint yields exactly those 14 items only under the no-persona layout. That entry is the new test's input, carried as bytes.

Most misparses were silent -- the shifted walk produces garbage items, which is where the "Unknown Firehose item" and "Unknown number size support" warnings came from. Where it ran off the body it returned Eof, and `get_chunkset_data` drops the whole firehose chunk on Err, so a single bad tracepoint cost every entry in its chunk: 18 chunks and 726 entries on the test archive, all recovered by this change.

The decision needs the catalog at firehose-body parse time, so parse_firehose_preamble now takes the CatalogChunk and resolves the persona once per chunk. No fixture in tests/test_data contains a 0x40 entry, so nothing else in the suite moves.