### PR TITLE
Revert "Read the inline persona only when the catalog records none"

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -125,31 +125,7 @@ pub struct CatalogPersona {
     uuid: String,
 }
 
-impl ProcessInfoEntry {
-    /// `persona_id` values that mean the catalog records no persona for the process.
-    ///
-    /// `0xFFFFFFFF` is what `log` itself renders as `NOPERSONA`; `0xAAAAAAAA` is an
-    /// uninitialized-memory pattern seen in the same field.
-    const NO_PERSONA: [u32; 2] = [0xFFFF_FFFF, 0xAAAA_AAAA];
-
-    /// The persona a `persona_id` field names, or `None` when it holds a sentinel.
-    pub(crate) fn persona(persona_id: u32) -> Option<u32> {
-        (!Self::NO_PERSONA.contains(&persona_id)).then_some(persona_id)
-    }
-}
-
 impl CatalogChunk {
-    /// The persona the catalog records for a process, if it records one.
-    ///
-    /// A firehose tracepoint carries its persona id inline only when this is `None`. When the
-    /// catalog already knows the persona, the entry still sets the `has_persona` flag but no
-    /// field follows it -- reading one anyway consumes the start of the item list and shifts
-    /// every field after it. See `FirehosePreamble::parse_firehose`.
-    pub fn persona_for(&self, first_proc_id: u64, second_proc_id: u32) -> Option<u32> {
-        self.catalog_process_info_entries
-            .get(&format!("{first_proc_id}_{second_proc_id}"))
-            .and_then(|entry| ProcessInfoEntry::persona(entry.persona_id))
-    }
     /// Parse log Catalog data. The log Catalog contains metadata related to log entries such as Process info, Subsystem info, and the compressed log entries
     pub fn parse_catalog(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, preamble) = LogPreamble::parse(input)?;
@@ -567,7 +543,6 @@ impl CatalogChunk {
 mod tests {
     use super::CatalogChunk;
     use crate::catalog::CatalogPersona;
-    use crate::catalog::ProcessInfoEntry;
     use std::fs;
     use std::path::PathBuf;
 
@@ -846,13 +821,5 @@ mod tests {
                 }
             ]
         )
-    }
-
-    #[test]
-    fn persona_sentinels_are_not_personas() {
-        assert_eq!(ProcessInfoEntry::persona(99), Some(99));
-        assert_eq!(ProcessInfoEntry::persona(1000), Some(1000));
-        assert_eq!(ProcessInfoEntry::persona(0xFFFF_FFFF), None);
-        assert_eq!(ProcessInfoEntry::persona(0xAAAA_AAAA), None);
     }
 }

--- a/src/chunks/firehose/activity.rs
+++ b/src/chunks/firehose/activity.rs
@@ -36,7 +36,6 @@ impl FirehoseActivity {
         data: &[u8],
         firehose_flags: u16,
         firehose_log_type: u8,
-        catalog_persona: Option<u32>,
     ) -> nom::IResult<&[u8], FirehoseActivity> {
         let mut activity = FirehoseActivity::default();
         let mut input = data;
@@ -78,18 +77,12 @@ impl FirehoseActivity {
         let has_persona = 0x40;
         if (firehose_flags & has_persona) != 0 {
             debug!("[macos-unifiedlogs] Activity Firehose log chunk has has_persona flag");
+            let (firehose_input, persona_id) = le_u32(input)?;
+
+            activity.persona_id = persona_id;
             activity.flags.push(MessageFlags::HasPersona);
 
-            // The persona is inline only when the catalog does not already record one for this
-            // process. When it does, the flag is still set but no field follows it.
-            match catalog_persona {
-                Some(persona_id) => activity.persona_id = persona_id,
-                None => {
-                    let (firehose_input, persona_id) = le_u32(input)?;
-                    activity.persona_id = persona_id;
-                    input = firehose_input;
-                }
-            }
+            input = firehose_input;
         }
 
         let activity_id_other = 0x200; // has_other_current_aid flag. In Activity log entries this is another activity id flag
@@ -164,7 +157,7 @@ mod tests {
         let test_flags = 573;
         let log_type: u8 = 0x1;
         let (_, results) =
-            FirehoseActivity::parse_activity(&test_data, test_flags, log_type, None).unwrap();
+            FirehoseActivity::parse_activity(&test_data, test_flags, log_type).unwrap();
         assert_eq!(results.activity_id, 64434);
         assert_eq!(results.sentinal, 2147483648);
         assert_eq!(results.pid, 236);

--- a/src/chunks/firehose/firehose_log.rs
+++ b/src/chunks/firehose/firehose_log.rs
@@ -5,7 +5,6 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use crate::catalog::CatalogChunk;
 use crate::chunks::firehose::activity::FirehoseActivity;
 use crate::chunks::firehose::loss::FirehoseLoss;
 use crate::chunks::firehose::nonactivity::FirehoseNonActivity;
@@ -142,10 +141,9 @@ impl FirehosePreamble {
     const REMNANT_DATA: u8 = 0x0;
 
     /// Parse the start of the Firehose data
-    pub fn parse_firehose_preamble<'a>(
-        firehose_input_data: &'a [u8],
-        catalog: &CatalogChunk,
-    ) -> nom::IResult<&'a [u8], FirehosePreamble> {
+    pub fn parse_firehose_preamble(
+        firehose_input_data: &[u8],
+    ) -> nom::IResult<&[u8], FirehosePreamble> {
         let mut firehose_data = FirehosePreamble::default();
 
         let (input, chunk_tag) = le_u32(firehose_input_data)?;
@@ -188,14 +186,10 @@ impl FirehosePreamble {
             take(public_data_size - public_data_nommed_size)(log_data)?;
 
         // Go through all the public data associated with log Firehose entry
-        // Whether the persona is inline in each tracepoint depends on the emitting process, not
-        // on the tracepoint, so it is resolved once per chunk.
-        let catalog_persona = catalog.persona_for(first_proc_id, second_proc_id);
-
         while !public_data.is_empty() {
             // Start parsing all of them public data
             let (firehose_input, firehose_public_data) =
-                FirehosePreamble::parse_firehose(public_data, catalog_persona)?;
+                FirehosePreamble::parse_firehose(public_data)?;
             public_data = firehose_input;
 
             // If not enough data remaining. End early
@@ -467,7 +461,7 @@ impl FirehosePreamble {
     }
 
     /// Parse all the different types of Firehose data (activity, non-activity, loss, trace, signpost)
-    fn parse_firehose(data: &[u8], catalog_persona: Option<u32>) -> nom::IResult<&[u8], Firehose> {
+    fn parse_firehose(data: &[u8]) -> nom::IResult<&[u8], Firehose> {
         let mut firehose_results = Firehose::default();
 
         let (input, log_activity_type) = le_u8(data)?;
@@ -504,17 +498,17 @@ impl FirehosePreamble {
 
         if log_activity_type == activity {
             let (activity_data, activity) =
-                FirehoseActivity::parse_activity(firehose_input, flags, log_type, catalog_persona)?;
+                FirehoseActivity::parse_activity(firehose_input, flags, log_type)?;
             firehose_input = activity_data;
             firehose_results.firehose_activity = activity;
         } else if log_activity_type == nonactivity {
             let (non_activity_data, non_activity) =
-                FirehoseNonActivity::parse_non_activity(firehose_input, flags, catalog_persona)?;
+                FirehoseNonActivity::parse_non_activity(firehose_input, flags)?;
             firehose_input = non_activity_data;
             firehose_results.firehose_non_activity = non_activity;
         } else if log_activity_type == signpost {
             let (process_data, firehose_signpost) =
-                FirehoseSignpost::parse_signpost(firehose_input, flags, catalog_persona)?;
+                FirehoseSignpost::parse_signpost(firehose_input, flags)?;
             firehose_input = process_data;
             firehose_results.firehose_signpost = firehose_signpost;
         } else if log_activity_type == loss {
@@ -729,7 +723,6 @@ impl FirehosePreamble {
 #[cfg(test)]
 mod tests {
     use super::{FirehoseItemData, FirehosePreamble};
-    use crate::catalog::CatalogChunk;
     use crate::chunks::firehose::firehose_log::{FirehoseItem, FirehoseItemType};
     use std::{fs::File, io::Read, path::PathBuf};
 
@@ -2808,11 +2801,8 @@ mod tests {
             0, 0, 0, 0, 0, 2, 1, 4, 0, 48, 57, 126, 0, 179, 232, 0, 0, 0, 0, 0, 0, 40, 101, 197, 1,
             16, 0, 12, 0, 178, 249, 0, 0, 0, 0, 0, 128, 105, 67, 61, 0, 0, 0, 0, 0,
         ];
-        let (mut data, firehose) = FirehosePreamble::parse_firehose_preamble(
-            &test_firehose_data,
-            &CatalogChunk::default(),
-        )
-        .unwrap();
+        let (mut data, firehose) =
+            FirehosePreamble::parse_firehose_preamble(&test_firehose_data).unwrap();
         assert_eq!(firehose.chunk_tag, 0x6001);
         assert_eq!(firehose.chunk_sub_tag, 0);
         assert_eq!(firehose.chunk_data_size, 4032);
@@ -2829,8 +2819,7 @@ mod tests {
 
         let mut firehouse_result_count = firehose.public_data.len();
         while !data.is_empty() {
-            let (test_data, firehose) =
-                FirehosePreamble::parse_firehose_preamble(data, &CatalogChunk::default()).unwrap();
+            let (test_data, firehose) = FirehosePreamble::parse_firehose_preamble(data).unwrap();
             data = test_data;
             firehouse_result_count += firehose.public_data.len();
         }
@@ -2854,7 +2843,7 @@ mod tests {
             51, 53, 48, 52, 53, 48, 40, 53, 48, 49, 41, 62, 58, 54, 52, 49, 93, 0, 0, 0, 0, 0, 0,
         ];
 
-        let (_, firehose) = FirehosePreamble::parse_firehose(&test_firehose_data, None).unwrap();
+        let (_, firehose) = FirehosePreamble::parse_firehose(&test_firehose_data).unwrap();
         assert_eq!(firehose.log_activity_type, 4);
         assert_eq!(firehose.log_type, 0);
         assert_eq!(firehose.flags, 557);
@@ -2931,8 +2920,7 @@ mod tests {
             22, 0, 8, 0, 140, 94, 64, 6, 1, 0, 0, 0, 4, 0, 4, 2, 96, 153, 65, 6, 175, 149, 170, 0,
             0, 0, 0, 0, 167, 26, 131, 253, 22, 0, 8, 0, 216, 115, 64, 6, 1, 0, 0, 0, 0, 0,
         ];
-        let (_, results) =
-            FirehosePreamble::parse_firehose_preamble(&data, &CatalogChunk::default()).unwrap();
+        let (_, results) = FirehosePreamble::parse_firehose_preamble(&data).unwrap();
         assert_eq!(results.private_data_virtual_offset, 4094);
         assert_eq!(results.first_number_proc_id, 1189179);
         assert_eq!(results.second_number_proc_id, 2685254);
@@ -2993,9 +2981,7 @@ mod tests {
             99, 47, 115, 101, 99, 117, 114, 105, 116, 121, 45, 99, 104, 101, 99, 107, 115, 121,
             115, 116, 101, 109, 0,
         ];
-        let (_, firehose) =
-            FirehosePreamble::parse_firehose_preamble(&test_data, &CatalogChunk::default())
-                .unwrap();
+        let (_, firehose) = FirehosePreamble::parse_firehose_preamble(&test_data).unwrap();
         assert_eq!(firehose.chunk_tag, 0x6001);
         assert_eq!(firehose.chunk_sub_tag, 0);
         assert_eq!(firehose.chunk_data_size, 163);
@@ -3219,8 +3205,7 @@ mod tests {
         let mut buffer = Vec::new();
         open.read_to_end(&mut buffer).unwrap();
 
-        let (_, results) =
-            FirehosePreamble::parse_firehose_preamble(&buffer, &CatalogChunk::default()).unwrap();
+        let (_, results) = FirehosePreamble::parse_firehose_preamble(&buffer).unwrap();
 
         assert_eq!(results.public_data.len(), 51);
 
@@ -3493,9 +3478,7 @@ mod tests {
             0, 0, 0, 0,
         ];
 
-        let (mut data, firehose) =
-            FirehosePreamble::parse_firehose_preamble(&test_data, &CatalogChunk::default())
-                .unwrap();
+        let (mut data, firehose) = FirehosePreamble::parse_firehose_preamble(&test_data).unwrap();
         assert_eq!(firehose.chunk_tag, 0x6001);
         assert_eq!(firehose.chunk_sub_tag, 0);
         assert_eq!(firehose.chunk_data_size, 4104);
@@ -3512,8 +3495,7 @@ mod tests {
 
         let mut firehouse_result_count = firehose.public_data.len();
         while !data.is_empty() {
-            let (test_data, firehose) =
-                FirehosePreamble::parse_firehose_preamble(data, &CatalogChunk::default()).unwrap();
+            let (test_data, firehose) = FirehosePreamble::parse_firehose_preamble(data).unwrap();
             data = test_data;
             firehouse_result_count += firehose.public_data.len();
         }
@@ -3615,49 +3597,5 @@ mod tests {
         };
 
         FirehosePreamble::parse_private_data(&[], &mut items).unwrap();
-    }
-
-    /// A non-activity tracepoint from a process whose catalog `ProcessInfoEntry` records a real
-    /// persona (`persona_id = 99`). `flags` has `0x40` set, but because the catalog already
-    /// knows the persona the tracepoint carries **no** inline persona field.
-    ///
-    /// 24-byte header, the 129-byte body its `data_size` states, then 7 bytes of padding.
-    /// Apple's `log show` renders it as:
-    ///
-    /// ```text
-    /// Requesting container lookup; personaid = 4294967295, type = NOPERSONA, name = <unknown>,
-    ///   origin [pid = 519, personaid = 4294967295], proximate [pid = 519, personaid = 4294967295],
-    ///   class = 4, identifier = <private>, group_identifier = <private>,
-    ///   create = 0, temp = 0, euid = 501, uid = 501
-    /// ```
-    const PERSONA_ABSENT_ENTRY: [u8; 160] = [
-        4, 0, 69, 6, 111, 222, 77, 13, 54, 26, 0, 0, 0, 0, 0, 0, 68, 163, 39, 91, 0, 0, 129, 0,
-        229, 87, 1, 0, 0, 0, 0, 128, 52, 196, 76, 13, 50, 0, 7, 35, 14, 0, 4, 255, 255, 255, 255,
-        34, 4, 0, 0, 10, 0, 34, 4, 10, 0, 10, 0, 0, 4, 7, 2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 4,
-        7, 2, 0, 0, 0, 4, 255, 255, 255, 255, 0, 8, 4, 0, 0, 0, 0, 0, 0, 0, 33, 4, 0, 0, 0, 0, 33,
-        4, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 4, 245, 1, 0, 0, 0, 4, 245, 1, 0, 0,
-        78, 79, 80, 69, 82, 83, 79, 78, 65, 0, 60, 117, 110, 107, 110, 111, 119, 110, 62, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0,
-    ];
-
-    #[test]
-    fn persona_field_is_absent_when_catalog_records_a_persona() {
-        let (_, firehose) =
-            FirehosePreamble::parse_firehose(&PERSONA_ABSENT_ENTRY, Some(99)).unwrap();
-
-        let items = &firehose.message.item_info;
-        assert_eq!(
-            items.len(),
-            14,
-            "expected the 14 items the format string takes"
-        );
-
-        let values: Vec<&str> = items.iter().map(|i| i.message_strings.as_str()).collect();
-        assert_eq!(values[1], "NOPERSONA");
-        assert_eq!(values[2], "<unknown>");
-        assert_eq!(values[3], "519");
-        assert_eq!(values[8], "<private>");
-        assert_eq!(values[12], "501");
-        assert_eq!(values[13], "501");
     }
 }

--- a/src/chunks/firehose/nonactivity.rs
+++ b/src/chunks/firehose/nonactivity.rs
@@ -35,7 +35,6 @@ impl FirehoseNonActivity {
     pub fn parse_non_activity(
         data: &[u8],
         firehose_flags: u16,
-        catalog_persona: Option<u32>,
     ) -> nom::IResult<&[u8], FirehoseNonActivity> {
         let mut non_activity = FirehoseNonActivity::default();
 
@@ -55,18 +54,12 @@ impl FirehoseNonActivity {
         let has_persona = 0x40;
         if (firehose_flags & has_persona) != 0 {
             debug!("[macos-unifiedlogs] Non-Activity Firehose log chunk has has_persona flag");
+            let (firehose_input, persona_id) = le_u32(input)?;
+
+            non_activity.persona_id = persona_id;
             non_activity.flags.push(MessageFlags::HasPersona);
 
-            // The persona is inline only when the catalog does not already record one for this
-            // process. When it does, the flag is still set but no field follows it.
-            match catalog_persona {
-                Some(persona_id) => non_activity.persona_id = persona_id,
-                None => {
-                    let (firehose_input, persona_id) = le_u32(input)?;
-                    non_activity.persona_id = persona_id;
-                    input = firehose_input;
-                }
-            }
+            input = firehose_input;
         }
 
         let private_string_range = 0x100; // has_private_data flag
@@ -173,7 +166,7 @@ mod tests {
         ];
         let test_flags = 556;
         let (_, nonactivity_results) =
-            FirehoseNonActivity::parse_non_activity(&test_data, test_flags, None).unwrap();
+            FirehoseNonActivity::parse_non_activity(&test_data, test_flags).unwrap();
         assert_eq!(nonactivity_results.activity_id, 0);
         assert_eq!(nonactivity_results.sentinel, 0);
         assert_eq!(nonactivity_results.private_strings_offset, 0);
@@ -260,7 +253,7 @@ mod tests {
             49, 52, 48, 57, 52, 49, 48, 0,
         ];
         let flags = 580;
-        let (_, result) = FirehoseNonActivity::parse_non_activity(&test, flags, None).unwrap();
+        let (_, result) = FirehoseNonActivity::parse_non_activity(&test, flags).unwrap();
         assert_eq!(
             result.flags,
             vec![

--- a/src/chunks/firehose/signpost.rs
+++ b/src/chunks/firehose/signpost.rs
@@ -36,7 +36,6 @@ impl FirehoseSignpost {
     pub fn parse_signpost(
         data: &[u8],
         firehose_flags: u16,
-        catalog_persona: Option<u32>,
     ) -> nom::IResult<&[u8], FirehoseSignpost> {
         let mut firehose_signpost = FirehoseSignpost::default();
 
@@ -56,18 +55,12 @@ impl FirehoseSignpost {
         let has_persona = 0x40;
         if (firehose_flags & has_persona) != 0 {
             debug!("[macos-unifiedlogs] Signpost Firehose has has_persona flag");
+            let (firehose_input, persona_id) = le_u32(input)?;
+
+            firehose_signpost.persona_id = persona_id;
             firehose_signpost.flags.push(MessageFlags::HasPersona);
 
-            // The persona is inline only when the catalog does not already record one for this
-            // process. When it does, the flag is still set but no field follows it.
-            match catalog_persona {
-                Some(persona_id) => firehose_signpost.persona_id = persona_id,
-                None => {
-                    let (firehose_input, persona_id) = le_u32(input)?;
-                    firehose_signpost.persona_id = persona_id;
-                    input = firehose_input;
-                }
-            }
+            input = firehose_input;
         }
 
         let private_string_range = 0x100; // has_private_data flag
@@ -188,7 +181,7 @@ mod tests {
             225, 244, 2, 0, 1, 0, 238, 238, 178, 178, 181, 176, 238, 238, 176, 63, 27, 0, 0, 0,
         ];
         let test_flags = 33282;
-        let (_, results) = FirehoseSignpost::parse_signpost(&test_data, test_flags, None).unwrap();
+        let (_, results) = FirehoseSignpost::parse_signpost(&test_data, test_flags).unwrap();
         assert_eq!(results.pc_id, 193761);
         assert_eq!(results.activity_id, 0);
         assert_eq!(results.sentinel, 0);
@@ -266,7 +259,7 @@ mod tests {
             219, 90, 1, 0, 0, 3, 0, 4, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 4, 10, 0, 0, 0,
         ];
         let flags = 33380;
-        let (_, result) = FirehoseSignpost::parse_signpost(&test, flags, None).unwrap();
+        let (_, result) = FirehoseSignpost::parse_signpost(&test, flags).unwrap();
         assert_eq!(
             result.flags,
             vec![

--- a/src/chunkset.rs
+++ b/src/chunkset.rs
@@ -162,8 +162,7 @@ impl ChunksetChunk {
         let simpledump_chunk = 0x6004;
 
         if chunk_type == firehose_chunk {
-            let firehose_results =
-                FirehosePreamble::parse_firehose_preamble(data, &unified_log_data.catalog);
+            let firehose_results = FirehosePreamble::parse_firehose_preamble(data);
             match firehose_results {
                 Ok((_, firehose_data)) => unified_log_data.firehose.push(firehose_data),
                 Err(err) => error!(


### PR DESCRIPTION
Reverts mandiant/macos-UnifiedLogs#152

@dgmcdona as im doing more deeper reviews in the tart golden gate logs and ios27.

Im thinking the persona_id is always inline actually.

Looking at the example test you added. I think i found it in the tart golden gate VM
```
    /// ```text
    /// Requesting container lookup; personaid = 4294967295, type = NOPERSONA, name = <unknown>,
    ///   origin [pid = 519, personaid = 4294967295], proximate [pid = 519, personaid = 4294967295],
    ///   class = 4, identifier = <private>, group_identifier = <private>,
    ///   create = 0, temp = 0, euid = 501, uid = 501
    /// ```

```

That log message entry actually appears corrupted.

From, `log raw-dump -H`

```
tp 16 + 153:        log default (has_current_aid, has_persona, shared_cache, has_subsystem, has_rules)
pubdata:            
00000000: 04 00 45 06 6f de 4d 0d 36 1a 00 00 00 00 00 00 ..E.o.M.6.......
00000010: 44 a3 27 5b 00 00 81 00 e5 57 01 00 00 00 00 80 D.'[.....W......
00000020: 34 c4 4c 0d 32 00 07 23 0e 00 04 ff ff ff ff 22 4.L.2..#......."
00000030: 04 00 00 0a 00 22 04 0a 00 0a 00 00 04 07 02 00 ....."..........
00000040: 00 00 04 ff ff ff ff 00 04 07 02 00 00 00 04 ff ................
00000050: ff ff ff 00 08 04 00 00 00 00 00 00 00 21 04 00 .............!..
00000060: 00 00 00 21 04 00 00 00 00 00 04 00 00 00 00 00 ...!............
00000070: 04 00 00 00 00 00 04 f5 01 00 00 00 04 f5 01 00 ................
00000080: 00 4e 4f 50 45 52 53 4f 4e 41 00 3c 75 6e 6b 6e .NOPERSONA.<unkn
00000090: 6f 77 6e 3e 00 00 00 00 00                      own>.....           thread:         0000000000001a36
    time:           +63.721s
    walltime:       1787065437 - 2026-08-18 08:03:57 (Tuesday)
    cur_aid:        80000000000157e5
    persona_id:     223134772
    location:       pc:0x23070032 fmt:0xd4dde6f
    image uuid:     7E90D1A2-7C3F-3B7D-A89C-93EB45173B4C
    image path:     /System/Library/PrivateFrameworks/MediaRemote.framework/Versions/A/MediaRemote
    format:         Requesting container lookup; personaid = %u, type = %{public}s, name = %{public}s, origin [pid = %d, personaid = %u], proximate [pid = %d, personaid = %u], class = %llu, identifier = %{private}s, group_identifier = %{private}s, create = %d, temp = %d, euid = %u, uid = %u
    subsystem:      14 com.apple.PlugInKit.holds
    ttl:            4
~~> failed to parse commands
```

I was able to find similar log messages.

```
tp 16 + 149:        log default (has_current_aid, shared_cache, has_subsystem, has_rules)
pubdata:            
00000000: 04 00 05 06 6f de 4d 0d 4e 0e 00 00 00 00 00 00 ....o.M.N.......
00000010: 00 6c 2b 17 00 00 7d 00 73 4b 00 00 00 00 00 80 .l+...}.sK......
00000020: 34 c4 4c 0d 06 00 07 23 0e 00 04 ff ff ff ff 22 4.L....#......."
00000030: 04 00 00 0a 00 22 04 0a 00 0a 00 00 04 00 00 00 ....."..........
00000040: 00 00 04 00 00 00 00 00 04 00 00 00 00 00 04 00 ................
00000050: 00 00 00 00 08 02 00 00 00 00 00 00 00 21 04 00 .............!..
00000060: 00 00 00 21 04 00 00 00 00 00 04 00 00 00 00 00 ...!............
00000070: 04 00 00 00 00 00 04 f5 01 00 00 00 04 f5 01 00 ................
00000080: 00 4e 4f 50 45 52 53 4f 4e 41 00 3c 75 6e 6b 6e .NOPERSONA.<unkn
00000090: 6f 77 6e 3e 00                                  own>.               thread:         0000000000000e4e
    time:           +16.196s
    walltime:       1787160843 - 2026-08-19 17:34:03 (Wednesday)
    cur_aid:        8000000000004b73
    location:       pc:0xd4cc434 fmt:0xd4dde6f
    image uuid:     B33F2B09-4BE9-32C5-954C-9233E1D5BB94
    image path:     /usr/lib/system/libsystem_containermanager.dylib
    format:         Requesting container lookup; personaid = %u, type = %{public}s, name = %{public}s, origin [pid = %d, personaid = %u], proximate [pid = %d, personaid = %u], class = %llu, identifier = %{private}s, group_identifier = %{private}s, create = %d, temp = %d, euid = %u, uid = %u
    subsystem:      6 com.apple.containermanager.xpc
    ttl:            7
Requesting container lookup; personaid = 4294967295, type = NOPERSONA, name = <unknown>, origin [pid = 0, personaid = 0], proximate [pid = 0, personaid = 0], class = 2, identifier = <private>, group_identifier = <private>, create = 0, temp = 0, euid = 501, uid = 501
```


This library returns:
```json
{
    "subsystem": "com.apple.containermanager",
    "thread_id": 70063,
    "pid": 33677,
    "euid": 501,
    "library": "/usr/lib/system/libsystem_containermanager.dylib",
    "library_uuid": "B33F2B094BE932C5954C9233E1D5BB94",
    "activity_id": 154979,
    "parent_activity_id": 0,
    "time": 1787161167285351000,
    "category": "xpc",
    "event_type": "Log",
    "log_type": "Default",
    "process": "/System/Library/PrivateFrameworks/CoreRecents.framework/Versions/A/Support/recentsd",
    "process_uuid": "72E8021B1B493258AF875DEDFA8D77A8",
    "message": "Requesting container lookup; personaid = -1, type = NOPERSONA, name = <unknown>, origin [pid = 0, personaid = 0], proximate [pid = 0, personaid = 0], class = 2, identifier = <private>, group_identifier = <private>, create = 0, temp = 0, euid = 501, uid = 501",
    "raw_message": "Requesting container lookup; personaid = %u, type = %{public}s, name = %{public}s, origin [pid = %d, personaid = %u], proximate [pid = %d, personaid = %u], class = %llu, identifier = %{private}s, group_identifier = %{private}s, create = %d, temp = %d, euid = %u, uid = %u",
    "boot_uuid": "49CA4B49A7A34F59A1EEA2DA8FA17BA1",
    "timezone_name": "GMT",
    "message_entries": [
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "-1",
            "item": "Number"
        },
        {
            "item_type": 34,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 10,
            "message_strings": "NOPERSONA",
            "item": "String"
        },
        {
            "item_type": 34,
            "item_type_size": 4,
            "offset": 10,
            "item_size": 10,
            "message_strings": "<unknown>",
            "item": "String"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 8,
            "offset": 0,
            "item_size": 0,
            "message_strings": "2",
            "item": "Number"
        },
        {
            "item_type": 33,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "<private>",
            "item": "PrivateString"
        },
        {
            "item_type": 33,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "<private>",
            "item": "PrivateString"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "501",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "501",
            "item": "Number"
        }
    ],
    "timestamp": "2026-08-19T17:39:27.285350912Z",
    "message_flags": [
        "HasCurrentAid",
        "SharedCache",
        "HasSubsystem",
        "HasRules"
    ],
    "evidence": "/Users/android/tart_goldengate.logarchive/Special/0000000000000008.tracev3"
}
```

```
tp 432 + 178:       log default (has_current_aid, has_persona, shared_cache, has_subsystem, has_rules)
pubdata:            
00000000: 04 00 45 06 6f de 4d 0d 06 24 02 00 00 00 00 00 ..E.o.M..$......
00000010: d4 8a 85 81 03 00 9a 00 76 34 04 00 00 00 00 80 ........v4......
00000020: e8 03 00 00 34 c4 4c 0d 23 00 07 23 0e 00 04 e8 ....4.L.#..#....
00000030: 03 00 00 22 04 00 00 08 00 22 04 08 00 25 00 00 ..."....."...%..
00000040: 04 5a 00 00 00 00 04 ff ff ff ff 00 04 db 28 01 .Z............(.
00000050: 00 00 04 e8 03 00 00 00 08 02 00 00 00 00 00 00 ................
00000060: 00 21 04 00 00 00 00 21 04 00 00 00 00 00 04 00 .!.....!........
00000070: 00 00 00 00 04 00 00 00 00 00 04 f5 01 00 00 00 ................
00000080: 04 f5 01 00 00 44 45 46 41 55 4c 54 00 46 45 45 .....DEFAULT.FEE
00000090: 44 45 45 45 45 2d 44 44 44 44 2d 43 43 43 43 2d DEEEE-DDDD-CCCC-
000000a0: 42 42 42 42 2d 30 30 30 30 30 30 30 30 30 31 46 BBBB-0000000001F
000000b0: 35 00                                           5.                  thread:         0000000000022406
    time:           +627.413s
    walltime:       1787161454 - 2026-08-19 17:44:14 (Wednesday)
    cur_aid:        8000000000043476
    persona_id:     1000
    location:       pc:0xd4cc434 fmt:0xd4dde6f
    image uuid:     B33F2B09-4BE9-32C5-954C-9233E1D5BB94
    image path:     /usr/lib/system/libsystem_containermanager.dylib
    format:         Requesting container lookup; personaid = %u, type = %{public}s, name = %{public}s, origin [pid = %d, personaid = %u], proximate [pid = %d, personaid = %u], class = %llu, identifier = %{private}s, group_identifier = %{private}s, create = %d, temp = %d, euid = %u, uid = %u
    subsystem:      35 com.apple.containermanager.xpc
    ttl:            7
Requesting container lookup; personaid = 1000, type = DEFAULT, name = FEEDEEEE-DDDD-CCCC-BBBB-0000000001F5, origin [pid = 90, personaid = 4294967295], proximate [pid = 75995, personaid = 1000], class = 2, identifier = <private>, group_identifier = <private>, create = 0, temp = 0, euid = 501, uid = 501
```

```json
{
    "subsystem": "com.apple.containermanager",
    "thread_id": 140294,
    "pid": 76027,
    "euid": 501,
    "library": "/usr/lib/system/libsystem_containermanager.dylib",
    "library_uuid": "B33F2B094BE932C5954C9233E1D5BB94",
    "activity_id": 275574,
    "parent_activity_id": 0,
    "time": 1787161454403809500,
    "category": "xpc",
    "event_type": "Log",
    "log_type": "Default",
    "process": "/System/Library/PrivateFrameworks/CloudPhotoServices.framework/Versions/A/XPCServices/com.apple.CloudPhotosConfiguration.xpc/Contents/MacOS/com.apple.CloudPhotosConfiguration",
    "process_uuid": "4936A3D0B2F43D839CEB505C52D6E925",
    "message": "Requesting container lookup; personaid = 1000, type = DEFAULT, name = FEEDEEEE-DDDD-CCCC-BBBB-0000000001F5, origin [pid = 90, personaid = -1], proximate [pid = 75995, personaid = 1000], class = 2, identifier = <private>, group_identifier = <private>, create = 0, temp = 0, euid = 501, uid = 501",
    "raw_message": "Requesting container lookup; personaid = %u, type = %{public}s, name = %{public}s, origin [pid = %d, personaid = %u], proximate [pid = %d, personaid = %u], class = %llu, identifier = %{private}s, group_identifier = %{private}s, create = %d, temp = %d, euid = %u, uid = %u",
    "boot_uuid": "49CA4B49A7A34F59A1EEA2DA8FA17BA1",
    "timezone_name": "GMT",
    "message_entries": [
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "1000",
            "item": "Number"
        },
        {
            "item_type": 34,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 8,
            "message_strings": "DEFAULT",
            "item": "String"
        },
        {
            "item_type": 34,
            "item_type_size": 4,
            "offset": 8,
            "item_size": 37,
            "message_strings": "FEEDEEEE-DDDD-CCCC-BBBB-0000000001F5",
            "item": "String"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "90",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "-1",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "75995",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "1000",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 8,
            "offset": 0,
            "item_size": 0,
            "message_strings": "2",
            "item": "Number"
        },
        {
            "item_type": 33,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "<private>",
            "item": "PrivateString"
        },
        {
            "item_type": 33,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "<private>",
            "item": "PrivateString"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "0",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "501",
            "item": "Number"
        },
        {
            "item_type": 0,
            "item_type_size": 4,
            "offset": 0,
            "item_size": 0,
            "message_strings": "501",
            "item": "Number"
        }
    ],
    "timestamp": "2026-08-19T17:44:14.403809536Z",
    "message_flags": [
        "HasCurrentAid",
        "HasPersona",
        "SharedCache",
        "HasSubsystem",
        "HasRules"
    ],
    "evidence": "/Users/android/tart_goldengate.logarchive/Special/0000000000000009.tracev3"
}
```


Looking at the iOS 27 logarchives. The persona ID is always inline regardless if the Catalog contains a person match Some(X).