### PR TITLE
Statedump plist fix

### DIFF
--- a/.changes/unreleased/Added-20260901-185024.yaml
+++ b/.changes/unreleased/Added-20260901-185024.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: lzbitmap decompression support
+time: 2026-09-01T18:50:24.904862634-04:00

--- a/.changes/unreleased/Added-20260901-185046.yaml
+++ b/.changes/unreleased/Added-20260901-185046.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Initial support for GoldenGate and iOS 27
+time: 2026-09-01T18:50:46.766658909-04:00

--- a/.changes/unreleased/Changed-20260901-185146.yaml
+++ b/.changes/unreleased/Changed-20260901-185146.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Include additional details for Simpledump and Statedump
+time: 2026-09-01T18:51:46.07158217-04:00

--- a/.changes/unreleased/Fixed-20260901-185234.yaml
+++ b/.changes/unreleased/Fixed-20260901-185234.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Bug when encountering plaintext plist in Statedump entries
+time: 2026-09-01T18:52:34.170133229-04:00

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -621,7 +621,7 @@ where
             let no_firehose_preamble = 1;
 
             let data_string = match statedump.unknown_data_type {
-                // Check in binary plist (bplist)
+                // Check for binary plist (bplist)
                 0x1 if statedump.statedump_data.starts_with(b"bplist") => {
                     Statedump::parse_statedump_plist(&statedump.statedump_data)
                 }

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -621,7 +621,26 @@ where
             let no_firehose_preamble = 1;
 
             let data_string = match statedump.unknown_data_type {
-                0x1 => Statedump::parse_statedump_plist(&statedump.statedump_data),
+                // Check in binary plist (bplist)
+                0x1 if statedump
+                    .statedump_data
+                    .starts_with(&[98, 112, 108, 105, 115, 116]) =>
+                {
+                    Statedump::parse_statedump_plist(&statedump.statedump_data)
+                }
+                // plist could also just be plaintext
+                0x1 => {
+                    let results = extract_string(&statedump.statedump_data);
+                    match results {
+                        Ok((_, string_data)) => string_data,
+                        Err(err) => {
+                            error!(
+                                "[macos-unifiedlogs] Failed to extract plist string from statedump: {err:?}"
+                            );
+                            String::from("Failed to extract plist string from statedump")
+                        }
+                    }
+                }
                 0x2 => match extract_protobuf(&statedump.statedump_data) {
                     Ok(map) => serde_json::to_string(&map)
                         .unwrap_or(String::from("Failed to serialize Protobuf HashMap")),

--- a/src/unified_log.rs
+++ b/src/unified_log.rs
@@ -622,10 +622,7 @@ where
 
             let data_string = match statedump.unknown_data_type {
                 // Check in binary plist (bplist)
-                0x1 if statedump
-                    .statedump_data
-                    .starts_with(&[98, 112, 108, 105, 115, 116]) =>
-                {
+                0x1 if statedump.statedump_data.starts_with(b"bplist") => {
                     Statedump::parse_statedump_plist(&statedump.statedump_data)
                 }
                 // plist could also just be plaintext


### PR DESCRIPTION
Minor fix when encountering plaintext plist data in Statedump entries.

Previously, the parser assumed plist entries were in binary format `bplist`.

However, the plist data can also be in plaintext